### PR TITLE
Revert "Reduce amount of unsafe and boilerplate for aligned PlaneData"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,3 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 wasm-bindgen = { version = "0.2.63", optional = true }
 rust_hawktracer = "0.7.0"
 new_debug_unreachable = "1.0.4"
-maligned = "0.2.1"


### PR DESCRIPTION
This reverts commit 0b0ff4bb0fc7aae4d51728ae5556ae0e362f2ae4.