### PR TITLE
Remove `cfg-if` and `noop-proc-macro` crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ tracing = [
 ]
 
 [dependencies]
-cfg-if = "1.0"
 num-traits = "0.2"
 num-derive = "0.4"
 noop_proc_macro = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ tracing = [
 [dependencies]
 num-traits = "0.2"
 num-derive = "0.4"
-noop_proc_macro = "0.3.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
 profiling = { version = "1" }
 tracing = { version = "0.1.40", optional = true }

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -10,10 +10,13 @@
 use crate::math::*;
 use crate::pixel::*;
 use crate::plane::*;
-use crate::serialize::{Deserialize, Serialize};
+
+#[cfg(feature = "serialize")]
+use serde::{Deserialize, Serialize};
 
 /// Represents a raw video frame
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct Frame<T: Pixel> {
     /// Planes constituting the frame.
     pub planes: [Plane<T>; 3],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,24 +84,19 @@ pub mod pixel;
 pub mod plane;
 
 mod serialize {
-    cfg_if::cfg_if! {
-       if #[cfg(feature="serialize")] {
-         pub use serde::*;
-        } else {
-          pub use noop_proc_macro::{Deserialize, Serialize};
-       }
-    }
+    #[cfg(feature = "serialize")]
+    pub use serde::*;
+
+    #[cfg(not(feature = "serialize"))]
+    pub use noop_proc_macro::{Deserialize, Serialize};
 }
 
 mod wasm_bindgen {
-    cfg_if::cfg_if! {
-      // Only use wasm_bindgen with wasm32-unknown-unknown, not wasm32-wasi
-      if #[cfg(all(target_arch = "wasm32", target_os = "unknown"))] {
-        pub use wasm_bindgen::prelude::*;
-      } else {
-        pub use noop_proc_macro::wasm_bindgen;
-      }
-    }
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    pub use wasm_bindgen::prelude::*;
+
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+    pub use noop_proc_macro::wasm_bindgen;
 }
 
 pub mod prelude {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,22 +83,6 @@ pub mod math;
 pub mod pixel;
 pub mod plane;
 
-mod serialize {
-    #[cfg(feature = "serialize")]
-    pub use serde::*;
-
-    #[cfg(not(feature = "serialize"))]
-    pub use noop_proc_macro::{Deserialize, Serialize};
-}
-
-mod wasm_bindgen {
-    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-    pub use wasm_bindgen::prelude::*;
-
-    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-    pub use noop_proc_macro::wasm_bindgen;
-}
-
 pub mod prelude {
     pub use crate::math::*;
     pub use crate::pixel::*;

--- a/src/pixel.rs
+++ b/src/pixel.rs
@@ -7,8 +7,8 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
-use crate::serialize::{Deserialize, Serialize};
-use crate::wasm_bindgen::*;
+#[cfg(feature = "serialize")]
+use serde::{Serialize, Deserialize};
 
 use num_derive::FromPrimitive;
 use num_traits::{AsPrimitive, PrimInt, Signed};
@@ -146,8 +146,8 @@ impl Coefficient for i32 {
 }
 
 /// Chroma subsampling format
-#[wasm_bindgen]
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, FromPrimitive, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, FromPrimitive)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[repr(C)]
 pub enum ChromaSampling {
     /// Both vertically and horizontally subsampled.

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -121,15 +121,11 @@ impl<T: Pixel> std::ops::DerefMut for PlaneData<T> {
 }
 
 impl<T: Pixel> PlaneData<T> {
-    // Data alignment in bytes.
-    cfg_if::cfg_if! {
-      if #[cfg(target_arch = "wasm32")] {
-        // FIXME: wasm32 allocator fails for alignment larger than 3
-        const DATA_ALIGNMENT: usize = 1 << 3;
-      } else {
-        const DATA_ALIGNMENT: usize = 1 << 6;
-      }
-    }
+    #[cfg(target_arch = "wasm32")]
+    // FIXME: wasm32 allocator fails for alignment larger than 3
+    const DATA_ALIGNMENT: usize = 1 << 3;
+    #[cfg(not(target_arch = "wasm32"))]
+    const DATA_ALIGNMENT: usize = 1 << 6;
 
     pub fn new(len: usize) -> Self {
         Self {

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -17,10 +17,13 @@ use aligned_vec::{ABox, AVec, ConstAlign};
 
 use crate::math::*;
 use crate::pixel::*;
-use crate::serialize::{Deserialize, Serialize};
+
+#[cfg(feature = "serialize")]
+use serde::{Deserialize, Serialize};
 
 /// Plane-specific configuration.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct PlaneConfig {
     /// Data stride.
     pub stride: usize,
@@ -147,7 +150,8 @@ impl<T: Pixel> PlaneData<T> {
 /// One data plane of a frame.
 ///
 /// For example, a plane can be a Y luma plane or a U or V chroma plane.
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct Plane<T: Pixel> {
     // TODO: it is used by encoder to copy by plane and by tiling, make it
     // private again once tiling is moved and a copy_plane fn is added.


### PR DESCRIPTION
This isn't very important, but it feels like these crates don't add much value in this project. I guess they were used in rav1e and just kept as-is?

I think that cfg-if is unnecessary for simple cfg attributes like this, and the noop_proc_macro is used so rarely that it barely reduces the amount of code.