### PR TITLE
Fix: Unsafe Undefined Behavior - Zero Sized `PlaneData`

### DIFF
--- a/src/plane.rs
+++ b/src/plane.rs
@@ -1060,6 +1060,10 @@ pub mod test {
     fn test_plane_zero_len() {
         let plane = Plane::<u8>::new(0, 0, 0, 0, 0, 0);
         assert_eq!(plane.data.len(), 0);
+        assert_eq!(*plane.data, []);
+        let copy = plane.clone();
+        assert_eq!(copy.data.len(), 0);
+        assert_eq!(*copy.data, []);
     }
 
     #[test]


### PR DESCRIPTION
Calls to `alloc` with [zero sized layouts is undefined behavior](https://doc.rust-lang.org/std/alloc/trait.GlobalAlloc.html#tymethod.alloc).
This is particularly problematic when using non-default allocators.
[Jemallocator](https://github.com/tikv/jemallocator) (using dev profile only) panics when a zero sized layout is used.
rav1e creates zero sized `Planes` in multiple [places](https://github.com/xiph/rav1e/blob/4b5c8f77b73fd58c7b5cec2302e3892660dd2bbb/src/api/lookahead.rs#L211-L216) to avoid the cost of allocation when the field is not used internally.

