### PR TITLE
Use aligned_vec crate to eliminate unsound code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 repository = "https://github.com/rust-av/v_frame"
 
 [features]
-serialize = ["serde"]
+serialize = ["serde", "aligned-vec/serde"]
 wasm = ["wasm-bindgen"]
 tracing = [
   "profiling/profile-with-tracing",
@@ -24,6 +24,7 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 wasm-bindgen = { version = "0.2.63", optional = true }
 profiling = { version = "1" }
 tracing = { version = "0.1.40", optional = true }
+aligned-vec = "0.5.0"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -102,9 +102,9 @@ pub struct PlaneOffset {
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct PlaneData<T: Pixel> {
     #[cfg(not(target_arch = "wasm32"))]
-    data: AVec<T, ConstAlign<{ 1 << 6 }>>,
+    data: ABox<[T], ConstAlign<{ 1 << 6 }>>,
     #[cfg(target_arch = "wasm32")]
-    data: AVec<T, ConstAlign<{ 1 << 3 }>>,
+    data: ABox<[T], ConstAlign<{ 1 << 3 }>>,
 }
 
 unsafe impl<T: Pixel + Send> Send for PlaneData<T> {}
@@ -140,13 +140,14 @@ impl<T: Pixel> PlaneData<T> {
             data: AVec::from_iter(
                 Self::DATA_ALIGNMENT,
                 iter::repeat(T::cast_from(0)).take(len),
-            ),
+            )
+            .into_boxed_slice(),
         }
     }
 
     fn from_slice(data: &[T]) -> Self {
         Self {
-            data: AVec::from_slice(Self::DATA_ALIGNMENT, data),
+            data: AVec::from_slice(Self::DATA_ALIGNMENT, data).into_boxed_slice(),
         }
     }
 }

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -7,19 +7,17 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
-use std::alloc::handle_alloc_error;
 use std::iter::FusedIterator;
 use std::marker::PhantomData;
 use std::mem;
 use std::ops::{Index, IndexMut, Range};
-use std::{
-    alloc::{alloc, dealloc, Layout},
-    u32,
-};
+use std::u32;
 use std::{
     fmt::{Debug, Display, Formatter},
     usize,
 };
+
+use aligned_vec::{avec_rt, AVec, RuntimeAlign};
 
 use crate::math::*;
 use crate::pixel::*;
@@ -100,86 +98,26 @@ pub struct PlaneOffset {
 ///
 /// The buffer is padded and aligned according to the architecture-specific
 /// SIMD constraints.
-#[derive(Debug, PartialEq, Eq)]
-#[cfg_attr(not(feature = "serialize"), derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct PlaneData<T: Pixel> {
-    ptr: std::ptr::NonNull<T>,
-    _marker: PhantomData<T>,
-    len: usize,
+    data: AVec<T, RuntimeAlign>,
 }
 
 unsafe impl<T: Pixel + Send> Send for PlaneData<T> {}
 unsafe impl<T: Pixel + Sync> Sync for PlaneData<T> {}
 
-impl<T: Pixel> Clone for PlaneData<T> {
-    fn clone(&self) -> Self {
-        // SAFETY: we initialize the plane data before returning
-        let mut pd = unsafe { Self::new_uninitialized(self.len) };
-
-        pd.copy_from_slice(self);
-
-        pd
-    }
-}
-
 impl<T: Pixel> std::ops::Deref for PlaneData<T> {
     type Target = [T];
 
     fn deref(&self) -> &[T] {
-        // SAFETY: we cannot reference out of bounds because we know the length of the data
-        unsafe {
-            let p = self.ptr.as_ptr();
-
-            std::slice::from_raw_parts(p, self.len)
-        }
+        self.data.as_slice()
     }
 }
 
 impl<T: Pixel> std::ops::DerefMut for PlaneData<T> {
     fn deref_mut(&mut self) -> &mut [T] {
-        // SAFETY: we cannot reference out of bounds because we know the length of the data
-        unsafe {
-            let p = self.ptr.as_ptr();
-
-            std::slice::from_raw_parts_mut(p, self.len)
-        }
-    }
-}
-
-impl<T: Pixel> std::ops::Drop for PlaneData<T> {
-    fn drop(&mut self) {
-        // SAFETY: we cannot dealloc too much because we know the length of the data
-        unsafe {
-            dealloc(self.ptr.as_ptr() as *mut u8, Self::layout(self.len));
-        }
-    }
-}
-
-#[cfg(feature = "serialize")]
-impl<T: Pixel + Serialize> Serialize for PlaneData<T> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        use serde::ser::SerializeSeq;
-        use std::ops::Deref;
-
-        let mut data = serializer.serialize_seq(Some(self.len))?;
-        for byte in self.deref() {
-            data.serialize_element(&byte)?;
-        }
-        data.end()
-    }
-}
-
-#[cfg(feature = "serialize")]
-impl<'de, T: Pixel + Deserialize<'de>> Deserialize<'de> for PlaneData<T> {
-    fn deserialize<D>(deserializer: D) -> Result<Self, <D as serde::Deserializer<'de>>::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let deserialized = Vec::deserialize(deserializer)?;
-        Ok(Self::from_slice(&deserialized))
+        self.data.as_mut_slice()
     }
 }
 
@@ -188,52 +126,22 @@ impl<T: Pixel> PlaneData<T> {
     cfg_if::cfg_if! {
       if #[cfg(target_arch = "wasm32")] {
         // FIXME: wasm32 allocator fails for alignment larger than 3
-        const DATA_ALIGNMENT_LOG2: usize = 3;
+        const DATA_ALIGNMENT: usize = 1 << 3;
       } else {
-        const DATA_ALIGNMENT_LOG2: usize = 6;
+        const DATA_ALIGNMENT: usize = 1 << 6;
       }
     }
 
-    unsafe fn layout(len: usize) -> Layout {
-        Layout::from_size_align(len * mem::size_of::<T>(), 1 << Self::DATA_ALIGNMENT_LOG2)
-            .expect("layout size too large")
-    }
-
-    unsafe fn new_uninitialized(len: usize) -> Self {
-        let ptr = {
-            let layout = Self::layout(len);
-            let ptr = alloc(layout) as *mut T;
-            if ptr.is_null() {
-                handle_alloc_error(layout);
-            }
-            std::ptr::NonNull::new_unchecked(ptr)
-        };
-
-        PlaneData {
-            ptr,
-            len,
-            _marker: PhantomData,
-        }
-    }
-
     pub fn new(len: usize) -> Self {
-        // SAFETY: we initialize the plane data before returning
-        let mut pd = unsafe { Self::new_uninitialized(len) };
-
-        for v in pd.iter_mut() {
-            *v = T::cast_from(128);
+        Self {
+            data: avec_rt!([Self::DATA_ALIGNMENT]| T::cast_from(0); len),
         }
-
-        pd
     }
 
     fn from_slice(data: &[T]) -> Self {
-        // SAFETY: we initialize the plane data before returning
-        let mut pd = unsafe { Self::new_uninitialized(data.len()) };
-
-        pd.copy_from_slice(data);
-
-        pd
+        Self {
+            data: AVec::from_slice(Self::DATA_ALIGNMENT, data),
+        }
     }
 }
 
@@ -275,21 +183,6 @@ impl<T: Pixel> Plane<T> {
     ) -> Self {
         let cfg = PlaneConfig::new(width, height, xdec, ydec, xpad, ypad, mem::size_of::<T>());
         let data = PlaneData::new(cfg.stride * cfg.alloc_height);
-
-        Plane { data, cfg }
-    }
-
-    /// Allocates and returns an uninitialized plane.
-    unsafe fn new_uninitialized(
-        width: usize,
-        height: usize,
-        xdec: usize,
-        ydec: usize,
-        xpad: usize,
-        ypad: usize,
-    ) -> Self {
-        let cfg = PlaneConfig::new(width, height, xdec, ydec, xpad, ypad, mem::size_of::<T>());
-        let data = PlaneData::new_uninitialized(cfg.stride * cfg.alloc_height);
 
         Plane { data, cfg }
     }
@@ -557,17 +450,14 @@ impl<T: Pixel> Plane<T> {
     /// - If the requested width and height are > half the input width or height
     pub fn downsampled(&self, frame_width: usize, frame_height: usize) -> Plane<T> {
         let src = self;
-        // SAFETY: all pixels initialized in this function
-        let mut new = unsafe {
-            Plane::new_uninitialized(
-                (src.cfg.width + 1) / 2,
-                (src.cfg.height + 1) / 2,
-                src.cfg.xdec + 1,
-                src.cfg.ydec + 1,
-                src.cfg.xpad / 2,
-                src.cfg.ypad / 2,
-            )
-        };
+        let mut new = Plane::new(
+            (src.cfg.width + 1) / 2,
+            (src.cfg.height + 1) / 2,
+            src.cfg.xdec + 1,
+            src.cfg.ydec + 1,
+            src.cfg.xpad / 2,
+            src.cfg.ypad / 2,
+        );
 
         let width = new.cfg.width;
         let height = new.cfg.height;
@@ -606,10 +496,7 @@ impl<T: Pixel> Plane<T> {
 
     /// Returns a plane downscaled from the source plane by a factor of `scale` (not padded)
     pub fn downscale<const SCALE: usize>(&self) -> Plane<T> {
-        // SAFETY: all pixels initialized when `downscale_in_place` is called
-        let mut new_plane = unsafe {
-            Plane::new_uninitialized(self.cfg.width / SCALE, self.cfg.height / SCALE, 0, 0, 0, 0)
-        };
+        let mut new_plane = Plane::new(self.cfg.width / SCALE, self.cfg.height / SCALE, 0, 0, 0, 0);
 
         self.downscale_in_place::<SCALE>(&mut new_plane);
 

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -139,7 +139,7 @@ impl<T: Pixel> PlaneData<T> {
         Self {
             data: AVec::from_iter(
                 Self::DATA_ALIGNMENT,
-                iter::repeat(T::cast_from(0)).take(len),
+                iter::repeat(T::cast_from(128)).take(len),
             )
             .into_boxed_slice(),
         }


### PR DESCRIPTION
This was created from the discussion in #23, to see how much performance impact we would have from swapping to a crate that provides an aligned Vec implementation. From the benchmarks within this crate, there seems to be some small amount of both positive and negative impact, depending on the benchmark at test. Change numbers below are compared to `main` branch.

```
frame new_with_padding padding=0
                        time:   [4.1241 µs 4.1381 µs 4.1629 µs]
                        change: [-7.6654% -7.1637% -6.7668%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 19 outliers among 100 measurements (19.00%)
  1 (1.00%) low severe
  5 (5.00%) low mild
  2 (2.00%) high mild
  11 (11.00%) high severe

frame new_with_padding padding!=0
                        time:   [6.6522 µs 6.6544 µs 6.6569 µs]
                        change: [-9.7115% -9.3830% -9.0024%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  1 (1.00%) low severe
  2 (2.00%) low mild
  8 (8.00%) high mild
  3 (3.00%) high severe

plane new padding=0     time:   [2.4437 µs 2.4523 µs 2.4656 µs]
                        change: [-1.6874% -1.4127% -1.0478%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  3 (3.00%) high severe

plane new padding!=0    time:   [3.3975 µs 3.4143 µs 3.4357 µs]
                        change: [-8.4273% -7.4063% -6.7211%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) high mild
  6 (6.00%) high severe

plane clone             time:   [5.8992 µs 5.9049 µs 5.9141 µs]
                        change: [+8.0155% +8.3304% +8.5803%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  4 (4.00%) high severe

plane pad               time:   [5.2718 µs 5.2953 µs 5.3186 µs]
                        change: [-1.3709% +0.5738% +2.5759%] (p = 0.57 > 0.05)
                        No change in performance detected.
Found 15 outliers among 100 measurements (15.00%)
  3 (3.00%) low severe
  5 (5.00%) low mild
  2 (2.00%) high mild
  5 (5.00%) high severe

plane copy_from_raw_u8 8-bit
                        time:   [8.3387 µs 8.3634 µs 8.3884 µs]
                        change: [+4.9790% +6.3446% +7.7890%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 16 outliers among 100 measurements (16.00%)
  3 (3.00%) low severe
  6 (6.00%) low mild
  2 (2.00%) high mild
  5 (5.00%) high severe

plane copy_from_raw_u8 10-bit
                        time:   [9.3816 µs 9.4546 µs 9.5246 µs]
                        change: [+5.9267% +7.0326% +8.2200%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 17 outliers among 100 measurements (17.00%)
  11 (11.00%) low mild
  2 (2.00%) high mild
  4 (4.00%) high severe

plane downsampled       time:   [11.012 µs 11.063 µs 11.152 µs]
                        change: [+4.6064% +5.0602% +5.6612%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  6 (6.00%) high severe

plane downscale         time:   [9.6774 µs 9.6804 µs 9.6839 µs]
                        change: [+5.1378% +5.3110% +5.4371%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  4 (4.00%) high severe

plane rows_iter         time:   [14.605 µs 14.677 µs 14.830 µs]
                        change: [-0.2160% +0.0117% +0.4976%] (p = 0.94 > 0.05)
                        No change in performance detected.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe

```