### PR TITLE
Update CI script

### DIFF
--- a/.github/workflows/crate.yml
+++ b/.github/workflows/crate.yml
@@ -34,6 +34,7 @@ jobs:
         --profile minimal
         -c rust-src
         -c miri
+        --
         nightly
 
         rustup default nightly
@@ -58,6 +59,7 @@ jobs:
         --profile minimal
         --allow-downgrade
         -c llvm-tools-preview
+        --
         stable
 
         rustup default stable

--- a/.github/workflows/crate.yml
+++ b/.github/workflows/crate.yml
@@ -9,6 +9,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
+  GRCOV_VERSION: v0.8.19
 
 jobs:
   build:
@@ -51,16 +52,12 @@ jobs:
         components: llvm-tools-preview
 
     - name: Install grcov
-      env:
-        GRCOV_LINK: https://github.com/mozilla/grcov/releases/download
-        GRCOV_VERSION: v0.8.19
-      run: |
-        curl -L "$GRCOV_LINK/$GRCOV_VERSION/grcov-x86_64-unknown-linux-musl.tar.bz2" |
-        tar xj -C $HOME/.cargo/bin
+      run: >
+        curl -L "https://github.com/mozilla/grcov/releases/download/$GRCOV_VERSION/grcov-x86_64-unknown-linux-musl.tar.bz2"
+        | tar xj -C "$HOME/.cargo/bin"
 
     - name: Run cargo clean
-      run: |
-        cargo clean
+      run: cargo clean
 
     - name: Run tests
       env:
@@ -71,8 +68,7 @@ jobs:
         RUSTDOCFLAGS: >
           -Cinstrument-coverage -Ccodegen-units=1 -Clink-dead-code
           -Coverflow-checks=off
-      run: |
-        cargo test --verbose
+      run: cargo test
     - name: Get coverage data for codecov
       run: |
         grcov . --binary-path ./target/debug/ -s . -t lcov --branch \

--- a/.github/workflows/crate.yml
+++ b/.github/workflows/crate.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
 
 jobs:
   build:
@@ -44,7 +45,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install Rust stable
+    - name: Install Rust stable and LLVM tools
       uses: dtolnay/rust-toolchain@stable
       with:
         components: llvm-tools-preview
@@ -52,7 +53,7 @@ jobs:
     - name: Install grcov
       env:
         GRCOV_LINK: https://github.com/mozilla/grcov/releases/download
-        GRCOV_VERSION: v0.8.7
+        GRCOV_VERSION: v0.8.19
       run: |
         curl -L "$GRCOV_LINK/$GRCOV_VERSION/grcov-x86_64-unknown-linux-musl.tar.bz2" |
         tar xj -C $HOME/.cargo/bin
@@ -63,7 +64,6 @@ jobs:
 
     - name: Run tests
       env:
-        CARGO_INCREMENTAL: 0
         LLVM_PROFILE_FILE: "{{ name }}-%p-%m.profraw"
         RUSTFLAGS: >
           -Cinstrument-coverage -Ccodegen-units=1 -Clink-dead-code

--- a/.github/workflows/crate.yml
+++ b/.github/workflows/crate.yml
@@ -90,6 +90,8 @@ jobs:
         grcov . --binary-path ./target/debug/ -s . -t lcov --branch \
               --ignore-not-existing --ignore "/*" --ignore "../*" -o lcov.info
     - name: Codecov upload
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
+        fail_ci_if_error: true
         files: lcov.info
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/crate.yml
+++ b/.github/workflows/crate.yml
@@ -28,16 +28,9 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install Rust nightly and miri
-      run: >
-        rustup toolchain install
-        --no-self-update
-        --profile minimal
-        -c rust-src
-        -c miri
-        --
-        nightly
-
-        rustup default nightly
+      uses: dtolnay/rust-toolchain@nightly
+      with:
+        components: miri, rust-src
 
     - name: Run miri
       env:
@@ -53,16 +46,9 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install Rust stable and LLVM tools
-      run: >
-        rustup toolchain install
-        --no-self-update
-        --profile minimal
-        --allow-downgrade
-        -c llvm-tools-preview
-        --
-        stable
-
-        rustup default stable
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        components: llvm-tools-preview
 
     - name: Install grcov
       env:

--- a/.github/workflows/crate.yml
+++ b/.github/workflows/crate.yml
@@ -74,7 +74,6 @@ jobs:
         grcov . --binary-path ./target/debug/ -s . -t lcov --branch \
               --ignore-not-existing --ignore "/*" --ignore "../*" -o lcov.info
     - name: Codecov upload
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v3
       with:
         files: lcov.info
-        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/crate.yml
+++ b/.github/workflows/crate.yml
@@ -28,9 +28,15 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install Rust nightly and miri
-      uses: dtolnay/rust-toolchain@nightly
-      with:
-        components: miri, rust-src
+      runs: >
+        rustup toolchain install
+        --no-self-update
+        --profile minimal
+        -c rust-src
+        -c miri
+        nightly
+
+        rustup default nightly
 
     - name: Run miri
       env:
@@ -46,9 +52,15 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install Rust stable and LLVM tools
-      uses: dtolnay/rust-toolchain@stable
-      with:
-        components: llvm-tools-preview
+      runs: >
+        rustup toolchain install
+        --no-self-update
+        --profile minimal
+        --allow-downgrade
+        -c llvm-tools-preview
+        stable
+
+        rustup default stable
 
     - name: Install grcov
       env:

--- a/.github/workflows/crate.yml
+++ b/.github/workflows/crate.yml
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install Rust nightly and miri
-      runs: >
+      run: >
         rustup toolchain install
         --no-self-update
         --profile minimal
@@ -52,7 +52,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install Rust stable and LLVM tools
-      runs: >
+      run: >
         rustup toolchain install
         --no-self-update
         --profile minimal

--- a/.github/workflows/crate.yml
+++ b/.github/workflows/crate.yml
@@ -74,7 +74,7 @@ jobs:
         grcov . --binary-path ./target/debug/ -s . -t lcov --branch \
               --ignore-not-existing --ignore "/*" --ignore "../*" -o lcov.info
     - name: Codecov upload
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v3
       with:
         fail_ci_if_error: true
         files: lcov.info

--- a/.github/workflows/crate.yml
+++ b/.github/workflows/crate.yml
@@ -74,8 +74,7 @@ jobs:
         grcov . --binary-path ./target/debug/ -s . -t lcov --branch \
               --ignore-not-existing --ignore "/*" --ignore "../*" -o lcov.info
     - name: Codecov upload
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
-        fail_ci_if_error: true
         files: lcov.info
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/crate.yml
+++ b/.github/workflows/crate.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build
       run: cargo build --verbose
     - name: Run tests
@@ -24,12 +24,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install Rust nightly and miri
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@nightly
       with:
-        toolchain: nightly
         components: miri, rust-src
 
     - name: Run miri
@@ -43,12 +42,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install Rust stable
       uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: stable
+        components: llvm-tools-preview
 
     - name: Install grcov
       env:
@@ -57,9 +56,6 @@ jobs:
       run: |
         curl -L "$GRCOV_LINK/$GRCOV_VERSION/grcov-x86_64-unknown-linux-musl.tar.bz2" |
         tar xj -C $HOME/.cargo/bin
-    - name: Install llvm-tools-preview
-      run: |
-        rustup component add llvm-tools-preview
 
     - name: Run cargo clean
       run: |


### PR DESCRIPTION
checkout v3 gives some warnings about outdated nodejs.

For `dtolnay/rust-toolchain`, it's not necessary to specify the `toolchain` variable when you use `dtolnay/rust-toolchain@stable`, `@nightly` etc.