### PR TITLE
Fix environment variable in CI script

### DIFF
--- a/.github/workflows/crate.yml
+++ b/.github/workflows/crate.yml
@@ -61,7 +61,7 @@ jobs:
 
     - name: Run tests
       env:
-        LLVM_PROFILE_FILE: "{{ name }}-%p-%m.profraw"
+        LLVM_PROFILE_FILE: "v_frame-%p-%m.profraw"
         RUSTFLAGS: >
           -Cinstrument-coverage -Ccodegen-units=1 -Clink-dead-code
           -Coverflow-checks=off


### PR DESCRIPTION
This shouldn't really cause problems, but it makes sense to use the correct name there.