### PR TITLE
Add WASM tests and CI job

### DIFF
--- a/.github/workflows/crate.yml
+++ b/.github/workflows/crate.yml
@@ -22,6 +22,23 @@ jobs:
     - name: Run tests
       run: cargo test --verbose
 
+  test-wasm:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack
+
+      - name: Run tests
+        run: wasm-pack test --headless --chrome --firefox
+
   miri:
     runs-on: ubuntu-latest
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,24 +24,38 @@ profiling = { version = "1" }
 tracing = { version = "0.1.40", optional = true }
 aligned-vec = "0.5.0"
 
-# Note: We need to differentiate between wasm32-unknown-unknown and
-# wasm32-wasi. cfg(target_arch = "wasm32") will match both.
+[[bench]]
+name = "bench"
+harness = false
 
-# We need to disable the default "rayon" feature on wasm32.
+#
+# WebAssembly/wasm32 target support below
+#
+# There are two main WASM targets:
+# - wasm32-unknown-unknown: Base WebAssembly standard, used in browsers
+# - wasm32-wasi: Newer extension/standard, comes with basic std library,
+#   not supported in browsers (yet)
+#
+# Some things work in all WASM configurations, some work only on one of these two,
+# some things don't work on wasm32 at all.
+#
+# wasm32-unknown-unknown requires wasm_bindgen and wasm_bindgen_test to work,
+# but these can cause problems on wasm32-wasi. So we use either
+# - target_arch = "wasm32" for things that (don't) work on all WebAssembly targets or
+# - explicit targetting for wasm32-unknown-unknown or wasm32-wasi.
+#   In Cargo.toml, this is done via [target.<target-triple>.dependencies]
+#   In code, this is done via cfg(all(target_arch = "wasm32", target_os = "wasi"/"unknown"))
+
+# The rayon feature does not work on any wasm32 target
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 criterion = "0.5"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 criterion = { version = "0.5", default-features = false }
 
-# wasm-bindgen is needed for wasm32-unknown-unknown, but not
-# for wasm32-wasi.
+# wasm-bindgen is only needed for wasm32-unknown-unknown and not other wasm32 targets
 [target.wasm32-unknown-unknown.dependencies]
 wasm-bindgen = "0.2"
 
 [target.wasm32-unknown-unknown.dev-dependencies]
 wasm-bindgen-test = "0.3"
-
-[[bench]]
-name = "bench"
-harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ repository = "https://github.com/rust-av/v_frame"
 
 [features]
 serialize = ["serde", "aligned-vec/serde"]
-wasm = ["wasm-bindgen"]
 tracing = [
   "profiling/profile-with-tracing",
   "dep:tracing"
@@ -21,13 +20,27 @@ num-traits = "0.2"
 num-derive = "0.4"
 noop_proc_macro = "0.3.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
-wasm-bindgen = { version = "0.2.63", optional = true }
 profiling = { version = "1" }
 tracing = { version = "0.1.40", optional = true }
 aligned-vec = "0.5.0"
 
-[dev-dependencies]
-criterion = { version = "0.5", features = ["html_reports"] }
+# Note: We need to differentiate between wasm32-unknown-unknown and
+# wasm32-wasi. cfg(target_arch = "wasm32") will match both.
+
+# We need to disable the default "rayon" feature on wasm32.
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+criterion = "0.5"
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+criterion = { version = "0.5", default-features = false }
+
+# wasm-bindgen is needed for wasm32-unknown-unknown, but not
+# for wasm32-wasi.
+[target.wasm32-unknown-unknown.dependencies]
+wasm-bindgen = "0.2"
+
+[target.wasm32-unknown-unknown.dev-dependencies]
+wasm-bindgen-test = "0.3"
 
 [[bench]]
 name = "bench"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,8 @@ mod serialize {
 
 mod wasm_bindgen {
     cfg_if::cfg_if! {
-      if #[cfg(feature="wasm")] {
+      // Only use wasm_bindgen with wasm32-unknown-unknown, not wasm32-wasi
+      if #[cfg(all(target_arch = "wasm32", target_os = "unknown"))] {
         pub use wasm_bindgen::prelude::*;
       } else {
         pub use noop_proc_macro::wasm_bindgen;

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -895,6 +895,13 @@ impl<'a, T: Pixel> IndexMut<usize> for PlaneMutSlice<'a, T> {
 pub mod test {
     use super::*;
 
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    use wasm_bindgen_test::*;
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
     #[test]
     fn copy_from_raw_u8() {
         #[rustfmt::skip]
@@ -919,6 +926,7 @@ pub mod test {
         assert_eq!(&input[..64], &plane.data[..64]);
     }
 
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
     #[test]
     fn copy_to_raw_u8() {
         #[rustfmt::skip]
@@ -943,6 +951,7 @@ pub mod test {
         assert_eq!(&output[..64], &plane.data[..64]);
     }
 
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
     #[test]
     fn test_plane_downsample() {
         #[rustfmt::skip]
@@ -983,6 +992,8 @@ pub mod test {
 
         assert_eq!(&expected[..], &v[..]);
     }
+
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
     #[test]
     fn test_plane_downsample_odd() {
         #[rustfmt::skip]
@@ -1023,6 +1034,7 @@ pub mod test {
         assert_eq!(&expected[..], &v[..]);
     }
 
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
     #[test]
     fn test_plane_downscale() {
         #[rustfmt::skip]
@@ -1063,6 +1075,7 @@ pub mod test {
         assert_eq!(&expected[..], &v[..]);
     }
 
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
     #[test]
     fn test_plane_downscale_odd() {
         #[rustfmt::skip]
@@ -1102,6 +1115,7 @@ pub mod test {
         assert_eq!(&expected[..], &v[..]);
     }
 
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
     #[test]
     fn test_plane_downscale_odd_2() {
         #[rustfmt::skip]
@@ -1144,6 +1158,7 @@ pub mod test {
         assert_eq!(&expected[..], &v[..]);
     }
 
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
     #[test]
     fn test_plane_pad() {
         #[rustfmt::skip]
@@ -1191,6 +1206,7 @@ pub mod test {
     );
     }
 
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
     #[test]
     fn test_pixel_iterator() {
         #[rustfmt::skip]


### PR DESCRIPTION
The way I understand it, there are 2 different "main" WASM configurations: `wasm32-unknown-unknown` which is the most basic WebAssembly configuration that is used by browsers, and `wasm32-wasi`, a [newer extension](https://github.com/WebAssembly/WASI) to wasm32 which comes with a (small) standard library and some sort of component model.

These two targets have different limitations and very different tooling in Rust. I'll try to give an overview:

| | no wasm | wasm32-unknown-unknown | wasm32-wasi |
| - | - | - | - |
| criterion | default | no rayon[^1] | no rayon |
| tests | `#[test]` | `#[wasm_bindgen_test]` | `#[test]` |
| test cmd | cargo test | wasm-pack test | [^2] |
| runtime | native | nodejs, browser | wasmtime, wasmer etc.[^3] |
| cfg | `target_arch != "wasm32"` | `target_arch = "wasm32"`,<br>`target_os = "unknown"` | `target_arch = "wasm32"`,<br>`target_os = "wasi"`[^4] |

That said, this PR implements a CI job and testing for `wasm32-unknown-unknown` in a way that should allow adding `wasm32-wasi` without breakage later.

- Remove `wasm` feature (now detected automatically)
- Split `criterion` dev-dependency into wasm and non-wasm
  - Disable default features on wasm
  - Disable html_reports feature in general (no benefit for CI, can be enabled locally if wanted)
- Add wasm-bindgen dependencies only for `wasm32-unknown-unknown`. Including these on `wasm32-wasi` seems to cause problems
- Add `#[wasm_bindgen_test]` attribute on all tests if `wasm32-unknown-unknown` is selected
- Add CI job that runs wasm32 tests on chrome and firefox (these are preinstalled on Ubuntu runners)

[^1]: rayon doesn't work on wasm32, at least not out of the box. In criterion this means `default-features = false`
[^2]: Either `cargo test --no-run` & `wasmtime <test binary>` (or wasmer etc.) or `cargo test` with a test runner set in config.toml
[^3]: The goal of WASI is to be "run anywhere", but browsers don't support it yet. https://webassembly.sh/ is one option to run WASI in a browser.
[^4]: `target_os = "wasi"` is probably good enough, but for completeness, target_arch should be included too.