### PR TITLE
Don't compile `profiling` library unless necessary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,8 @@ repository = "https://github.com/rust-av/v_frame"
 
 [features]
 serialize = ["serde", "aligned-vec/serde"]
-tracing = [
-  "profiling/profile-with-tracing",
-  "dep:tracing"
-]
+profiling = ["dep:profiling"]
+tracing = ["profiling", "dep:tracing", "profiling/profile-with-tracing"]
 
 [dependencies]
 cfg-if = "1.0"
@@ -20,9 +18,11 @@ num-traits = "0.2"
 num-derive = "0.4"
 noop_proc_macro = "0.3.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
-profiling = { version = "1" }
-tracing = { version = "0.1.40", optional = true }
 aligned-vec = "0.5.0"
+
+# Profiling dependencies
+profiling = { version = "1", optional = true }
+tracing = { version = "0.1.40", optional = true }
 
 [[bench]]
 name = "bench"

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -511,7 +511,7 @@ impl<T: Pixel> Plane<T> {
     /// # Panics
     ///
     /// - If the current plane's width and height are not at least `SCALE` times the `in_plane`'s
-    #[profiling::function(downscale_in_place)]
+    #[cfg_attr(feature = "profiling", profiling::function(downscale_in_place))]
     pub fn downscale_in_place<const SCALE: usize>(&self, in_plane: &mut Plane<T>) {
         let stride = in_plane.cfg.stride;
         let width = in_plane.cfg.width;


### PR DESCRIPTION
I don't think there's any reason to add `profiling::function(..)` attributes when there's no profiling backend selected.
 
The `tracing` feature still works like before. `cargo b -F tracing` auto-enables the required `profiling` feature. `cargo b -F profiling` compiles the profiling harness without any backends, which doesn't really do anything except for increasing compile time.