### PR TITLE
Remove num-derive dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ tracing = ["profiling", "dep:tracing", "profiling/profile-with-tracing"]
 
 [dependencies]
 num-traits = "0.2"
-num-derive = "0.4"
 serde = { version = "1.0", features = ["derive"], optional = true }
 aligned-vec = "0.5.0"
 

--- a/src/pixel.rs
+++ b/src/pixel.rs
@@ -223,3 +223,29 @@ impl ChromaSampling {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn chroma_sampling_from_int() {
+        let expected = [
+            (-1, None),
+            (0, Some(ChromaSampling::Cs420)),
+            (1, Some(ChromaSampling::Cs422)),
+            (2, Some(ChromaSampling::Cs444)),
+            (3, Some(ChromaSampling::Cs400)),
+            (4, None),
+        ];
+
+        for (int, chroma_sampling) in expected {
+            let converted = ChromaSampling::from_i32(int);
+            assert_eq!(chroma_sampling, converted);
+
+            let converted_uint = ChromaSampling::from_u32(int as u32);
+            assert_eq!(chroma_sampling, converted_uint, "FromPrimitive does not return the same result for i32 and u32");
+        }
+    }
+}
+

--- a/src/pixel.rs
+++ b/src/pixel.rs
@@ -10,8 +10,7 @@
 #[cfg(feature = "serialize")]
 use serde::{Serialize, Deserialize};
 
-use num_derive::FromPrimitive;
-use num_traits::{AsPrimitive, PrimInt, Signed};
+use num_traits::{AsPrimitive, FromPrimitive, PrimInt, Signed};
 
 use std::fmt;
 use std::fmt::{Debug, Display};
@@ -146,7 +145,7 @@ impl Coefficient for i32 {
 }
 
 /// Chroma subsampling format
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, FromPrimitive)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[repr(C)]
 pub enum ChromaSampling {
@@ -159,6 +158,24 @@ pub enum ChromaSampling {
     Cs444,
     /// Monochrome.
     Cs400,
+}
+
+impl FromPrimitive for ChromaSampling {
+    fn from_i64(n: i64) -> Option<Self> {
+        use ChromaSampling::*;
+
+        match n {
+            n if n == Cs420 as i64 => Some(Cs420),
+            n if n == Cs422 as i64 => Some(Cs422),
+            n if n == Cs444 as i64 => Some(Cs444),
+            n if n == Cs400 as i64 => Some(Cs400),
+            _ => None,
+        }
+    }
+
+    fn from_u64(n: u64) -> Option<Self> {
+        ChromaSampling::from_i64(n as i64)
+    }
 }
 
 impl fmt::Display for ChromaSampling {

--- a/src/pixel.rs
+++ b/src/pixel.rs
@@ -228,6 +228,13 @@ impl ChromaSampling {
 mod test {
     use super::*;
 
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    use wasm_bindgen_test::*;
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
     #[test]
     fn chroma_sampling_from_int() {
         let expected = [


### PR DESCRIPTION
I checked that the implementation is equivalent with `cargo expand`.

This change removes `syn` from the build with default features and reduces compile times by roughly 50% on my machine. I think that's good enough to warrant ~15 lines of boilerplate.