### PR TITLE
Allow aligned-vec versions 0.5 and 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ tracing = ["profiling", "dep:tracing", "profiling/profile-with-tracing"]
 [dependencies]
 num-traits = "0.2"
 serde = { version = "1.0", features = ["derive"], optional = true }
-aligned-vec = "0.5.0"
+aligned-vec = ">=0.5.0, <0.7"
 
 # Profiling dependencies
 profiling = { version = "1", optional = true }


### PR DESCRIPTION
0.6.0 was released recently and seems to be compatible with 0.5.0, at least for the usage in v_frame. `rav1e` already updated to 0.6.0 and allowing both 0.5 and 0.6 should allow dependency deduplication for more crate users.