### PR TITLE
frame.rs module tests

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -65,3 +65,19 @@ impl<T: Pixel> Frame<T> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_1280x720_420_subsampling_no_padding() {
+        let frame = Frame::<u8>::new_with_padding(1280, 720, ChromaSampling::Cs420, 0);
+        assert_eq!(1280, frame.planes[0].cfg.width);
+        assert_eq!(720, frame.planes[0].cfg.height);
+        assert_eq!(640, frame.planes[1].cfg.width);
+        assert_eq!(360, frame.planes[1].cfg.height);
+        assert_eq!(640, frame.planes[2].cfg.width);
+        assert_eq!(360, frame.planes[2].cfg.height);
+    }
+}

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -70,14 +70,69 @@ impl<T: Pixel> Frame<T> {
 mod tests {
     use super::*;
 
+    type TestPixel = u8;
+
+    fn get_plane_resolution(plane: &Plane<TestPixel>) -> (usize, usize) {
+        (plane.cfg.width, plane.cfg.height)
+    }
+
+    fn test_frame_resolutions(
+        resolution: (usize, usize),
+        chroma_sampling: ChromaSampling,
+        expected_luma_res: (usize, usize),
+        expected_chroma_res: (usize, usize),
+        luma_padding: usize,
+    ) {
+        let (width, height) = resolution;
+        let frame =
+            Frame::<TestPixel>::new_with_padding(width, height, chroma_sampling, luma_padding);
+
+        assert_eq!(expected_luma_res, get_plane_resolution(&frame.planes[0]));
+        assert_eq!(expected_chroma_res, get_plane_resolution(&frame.planes[1]));
+        assert_eq!(expected_chroma_res, get_plane_resolution(&frame.planes[2]));
+    }
+
     #[test]
     fn test_1280x720_420_subsampling_no_padding() {
-        let frame = Frame::<u8>::new_with_padding(1280, 720, ChromaSampling::Cs420, 0);
-        assert_eq!(1280, frame.planes[0].cfg.width);
-        assert_eq!(720, frame.planes[0].cfg.height);
-        assert_eq!(640, frame.planes[1].cfg.width);
-        assert_eq!(360, frame.planes[1].cfg.height);
-        assert_eq!(640, frame.planes[2].cfg.width);
-        assert_eq!(360, frame.planes[2].cfg.height);
+        test_frame_resolutions(
+            (1280, 720),
+            ChromaSampling::Cs420,
+            (1280, 720),
+            (640, 360),
+            0,
+        );
+    }
+
+    #[test]
+    fn test_1920x1080_420_subsampling_no_padding() {
+        test_frame_resolutions(
+            (1920, 1080),
+            ChromaSampling::Cs420,
+            (1920, 1080),
+            (960, 540),
+            0,
+        );
+    }
+
+    #[test]
+    fn test_1280x720_444_subsampling_no_padding() {
+        test_frame_resolutions(
+            (1280, 720),
+            ChromaSampling::Cs444,
+            (1280, 720),
+            (1280, 720),
+            0,
+        );
+    }
+
+    #[test]
+    fn test_1280x720_444_subsampling_2_padding() {
+        test_frame_resolutions(
+            (1280, 720),
+            ChromaSampling::Cs444,
+            (1280, 720),
+            (1280, 720),
+            2,
+        );
     }
 }


### PR DESCRIPTION
I have added some tests for the frame.rs module. They may be made more concise by adding a crate that implements parameterized tests, as the logic of the Frame struct is pretty simple and most of the variations are due to resolution and padding changes.