### PR TITLE
RFC: Remove aligned-vec dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ repository = "https://github.com/rust-av/v_frame"
 include = ["Cargo.toml", "README.md", "LICENSE", "src"]
 
 [dependencies]
-aligned-vec = "0.6.4"
 num-traits = "0.2.19"
 thiserror = "2.0.17"
 
@@ -129,7 +128,6 @@ mod_module_files = "warn"
 needless_continue = "warn"
 needless_pass_by_ref_mut = "warn"
 option_as_ref_cloned = "warn"
-option_if_let_else = "warn"
 pathbuf_init_then_push = "warn"
 precedence_bits = "warn"
 range_minus_one = "warn"

--- a/src/pixel.rs
+++ b/src/pixel.rs
@@ -24,6 +24,13 @@
 
 use num_traits::PrimInt;
 
+mod private {
+    pub trait Sealed {}
+
+    impl Sealed for u8 {}
+    impl Sealed for u16 {}
+}
+
 /// A trait for types that can be used as pixel data.
 ///
 /// This trait abstracts over the pixel data types supported by the library,
@@ -41,10 +48,21 @@ use num_traits::PrimInt;
 ///
 /// Attempting to create a frame with a mismatched type will result in
 /// [`Error::DataTypeMismatch`](crate::error::Error::DataTypeMismatch).
-pub trait Pixel: Copy + Clone + Default + Send + Sync + PrimInt + 'static {}
+///
+/// # Safety
+///
+/// All implementing types must be valid if represented by an all-zero byte-pattern,
+/// i.e. using [`std::mem::zeroed`] must __not__ cause undefined behavior for
+/// implementing types.
+pub unsafe trait Pixel:
+    Copy + Clone + Default + Send + Sync + PrimInt + 'static + private::Sealed
+{
+}
 
 /// Pixel implementation for 8-bit video data.
-impl Pixel for u8 {}
+// SAFETY: u8 is valid if represented by a zeroed byte.
+unsafe impl Pixel for u8 {}
 
 /// Pixel implementation for high bit-depth (9-16 bit) video data.
-impl Pixel for u16 {}
+// SAFETY: u16 is valid if represented by zeroed bytes.
+unsafe impl Pixel for u16 {}

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -33,22 +33,12 @@
 #[cfg(test)]
 mod tests;
 
-use std::{
-    iter,
-    num::{NonZeroU8, NonZeroUsize},
-};
+use std::num::{NonZeroU8, NonZeroUsize};
 
-use aligned_vec::{ABox, AVec, ConstAlign};
+mod aligned;
+use aligned::AlignedData;
 
 use crate::{error::Error, pixel::Pixel};
-
-/// Alignment for plane data on WASM platforms (8 bytes).
-#[cfg(target_arch = "wasm32")]
-const DATA_ALIGNMENT: usize = 1 << 3;
-
-/// Alignment for plane data on non-WASM platforms (64 bytes for SIMD optimization).
-#[cfg(not(target_arch = "wasm32"))]
-const DATA_ALIGNMENT: usize = 1 << 6;
 
 /// A two-dimensional plane of pixel data with optional padding.
 ///
@@ -74,10 +64,10 @@ const DATA_ALIGNMENT: usize = 1 << 6;
 /// - [`rows()`](Plane::rows) / [`rows_mut()`](Plane::rows_mut): Iterate over all visible rows
 /// - [`pixel()`](Plane::pixel) / [`pixel_mut()`](Plane::pixel_mut): Access individual pixels
 /// - [`pixels()`](Plane::pixels) / [`pixels_mut()`](Plane::pixels_mut): Iterate over all visible pixels
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Plane<T: Pixel> {
     /// The underlying pixel data buffer, including padding.
-    pub(crate) data: ABox<[T], ConstAlign<DATA_ALIGNMENT>>,
+    pub(crate) data: AlignedData<T>,
     /// Geometry information describing dimensions and padding.
     pub(crate) geometry: PlaneGeometry,
 }
@@ -92,12 +82,11 @@ where
             .height
             .saturating_add(geometry.pad_top)
             .saturating_add(geometry.pad_bottom);
+
+        let pixels = rows.get() * geometry.stride.get();
+
         Self {
-            data: AVec::from_iter(
-                DATA_ALIGNMENT,
-                iter::repeat_n(T::zero(), geometry.stride.get() * rows.get()),
-            )
-            .into_boxed_slice(),
+            data: AlignedData::new(pixels),
             geometry,
         }
     }

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -126,11 +126,9 @@ where
     #[inline]
     #[must_use]
     pub fn rows(&self) -> impl DoubleEndedIterator<Item = &[T]> + ExactSizeIterator {
-        let origin = self.geometry.stride.get() * self.geometry.pad_top;
-        // SAFETY: The plane creation interface ensures the data is large enough
-        let visible_data = unsafe { self.data.get_unchecked(origin..) };
-        visible_data
+        self.data
             .chunks_exact(self.geometry.stride.get())
+            .skip(self.geometry.pad_top)
             .take(self.geometry.height.get())
             .map(|row| {
                 let start_idx = self.geometry.pad_left;
@@ -144,11 +142,9 @@ where
     /// in the plane, from top to bottom.
     #[inline]
     pub fn rows_mut(&mut self) -> impl DoubleEndedIterator<Item = &mut [T]> + ExactSizeIterator {
-        let origin = self.geometry.stride.get() * self.geometry.pad_top;
-        // SAFETY: The plane creation interface ensures the data is large enough
-        let visible_data = unsafe { self.data.get_unchecked_mut(origin..) };
-        visible_data
+        self.data
             .chunks_exact_mut(self.geometry.stride.get())
+            .skip(self.geometry.pad_top)
             .take(self.geometry.height.get())
             .map(|row| {
                 let start_idx = self.geometry.pad_left;

--- a/src/plane/aligned.rs
+++ b/src/plane/aligned.rs
@@ -183,3 +183,82 @@ impl<T> Drop for AlignedData<T> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty() {
+        AlignedData::<u8>::new(0);
+        AlignedData::<u16>::new(0);
+        // would not compile:
+        // AlignedData::<String>::new(0);
+    }
+
+    #[test]
+    fn empty_uninit() {
+        AlignedData::<u8>::new_uninit(0);
+        AlignedData::<u16>::new_uninit(0);
+        AlignedData::<String>::new_uninit(0);
+    }
+
+    #[test]
+    fn basic_zeroed() {
+        let data = AlignedData::<u16>::new(512);
+
+        #[expect(
+            clippy::needless_collect,
+            reason = "explicit collect so we can drop(data) before iterating"
+        )]
+        let vec: Vec<_> = data
+            .iter()
+            .enumerate()
+            .map(|(idx, val)| *val as usize + idx)
+            .collect();
+
+        drop(data);
+
+        for (idx, v) in vec.into_iter().enumerate() {
+            assert_eq!(idx, v);
+        }
+    }
+
+    #[test]
+    fn uninit_manual() {
+        let mut data = AlignedData::<u8>::new_uninit(256);
+        for (idx, x) in data.iter_mut().enumerate() {
+            x.write((idx % 42) as u8);
+        }
+
+        // SAFETY: Initialized above.
+        let data = unsafe { data.assume_init() };
+        println!("{:?}", &data[100..140]);
+    }
+
+    #[test]
+    fn uninit_with_drop() {
+        let mut data = AlignedData::<String>::new_uninit(3);
+        data[0].write("Hello World".into());
+        data[1].write(String::new());
+        data[2].write("This is a test".into());
+
+        // SAFETY: Initialized above.
+        let data = unsafe { data.assume_init() };
+        println!("{:?}", &*data);
+    }
+
+    #[test]
+    fn clone() {
+        let mut data = AlignedData::<String>::new_uninit(3);
+        data[0].write("Hello World".into());
+        data[1].write(String::new());
+        data[2].write("This is a test".into());
+
+        // SAFETY: Initialized above.
+        let data = unsafe { data.assume_init() };
+        let data2 = data.clone();
+        drop(data);
+        println!("{:?}", &*data2);
+    }
+}

--- a/src/plane/aligned.rs
+++ b/src/plane/aligned.rs
@@ -1,0 +1,185 @@
+use std::alloc::{Layout, alloc, alloc_zeroed, dealloc, handle_alloc_error};
+use std::fmt::Debug;
+use std::marker::PhantomData;
+use std::mem::{ManuallyDrop, MaybeUninit};
+use std::num::NonZeroUsize;
+use std::ops::{Deref, DerefMut};
+use std::ptr::NonNull;
+
+use crate::pixel::Pixel;
+
+/// Alignment for plane data on WASM platforms (8 bytes).
+#[cfg(target_arch = "wasm32")]
+const DATA_ALIGNMENT: usize = 1 << 3;
+
+/// Alignment for plane data on non-WASM platforms (64 bytes for SIMD optimization).
+#[cfg(not(target_arch = "wasm32"))]
+const DATA_ALIGNMENT: usize = 1 << 6;
+
+pub struct AlignedData<T> {
+    ptr: NonNull<[T]>,
+    _marker: PhantomData<T>,
+}
+
+// SAFETY: `ptr` is unique, we have exclusive access to the data and all access to
+//         the underlying data follows Rust borrowing/aliasing rules.
+unsafe impl<T: Send> Send for AlignedData<T> {}
+// SAFETY: See above.
+unsafe impl<T: Sync> Sync for AlignedData<T> {}
+
+impl<T> AlignedData<T> {
+    const fn layout(len: NonZeroUsize) -> Layout {
+        const { assert!(DATA_ALIGNMENT.is_power_of_two()) };
+        let t_size = const { NonZeroUsize::new(size_of::<T>()).expect("T is Sized") };
+
+        let size = len
+            .checked_mul(t_size)
+            .expect("allocation size does not overflow usize");
+
+        match Layout::from_size_align(size.get(), DATA_ALIGNMENT) {
+            Ok(l) => l,
+            _ => panic!("invalid layout"),
+        }
+    }
+
+    pub fn new_uninit(len: usize) -> AlignedData<MaybeUninit<T>> {
+        let ptr = if let Some(len) = NonZeroUsize::new(len) {
+            let layout = Self::layout(len);
+            // SAFETY: `Self::layout` guarantees that the layout is valid and has nonzero size.
+            let ptr = unsafe { alloc(layout) as *mut MaybeUninit<T> };
+            let Some(ptr) = NonNull::new(ptr) else {
+                handle_alloc_error(layout);
+            };
+
+            NonNull::slice_from_raw_parts(ptr, len.get())
+        } else {
+            NonNull::slice_from_raw_parts(NonNull::dangling(), 0)
+        };
+
+        AlignedData {
+            ptr,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T> AlignedData<MaybeUninit<T>> {
+    /// Converts to [`AlignedData<T>`].
+    ///
+    /// # Safety
+    /// It is up to the caller to ensure that all contained values are
+    /// initialized properly (see [`MaybeUninit::assume_init`]).
+    pub unsafe fn assume_init(self) -> AlignedData<T> {
+        // The underlying memory would usually be deallocated when `Drop`
+        // is run at the end of this scope. It needs to stay valid, so
+        // inhibit the destructor here.
+        let this = ManuallyDrop::new(self);
+
+        AlignedData {
+            ptr: NonNull::slice_from_raw_parts(this.ptr.cast(), this.len()),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T: Pixel> AlignedData<T> {
+    /// Zeroed.
+    pub fn new(len: usize) -> Self {
+        let ptr = if let Some(len) = NonZeroUsize::new(len) {
+            let layout = Self::layout(len);
+            // SAFETY:
+            // - `Self::layout` guarantees that the layout is valid and has nonzero size
+            // - The Pixel trait guarantees that zeroed memory is a valid T
+            let ptr = unsafe { alloc_zeroed(layout) as *mut T };
+            let Some(ptr) = NonNull::new(ptr) else {
+                handle_alloc_error(layout);
+            };
+
+            NonNull::slice_from_raw_parts(ptr, len.get())
+        } else {
+            NonNull::slice_from_raw_parts(NonNull::dangling(), 0)
+        };
+
+        Self {
+            ptr,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T> Deref for AlignedData<T> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        // SAFETY:
+        // - `self.ptr` is non-null and valid for `len` reads of `T`
+        // - `self.ptr` + `len` describe a single allocation
+        // - `self.ptr` is properly aligned (allocated with a valid Layout)
+        // - all values of T are properly initialized, either via zeroing
+        //   or manually before calling `Self::assume_init`
+        // - immutable borrow is upheld by `&self`
+        unsafe { self.ptr.as_ref() }
+    }
+}
+
+impl<T> DerefMut for AlignedData<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        // SAFETY: See `deref` above. Additionally:
+        // - `self.ptr` is valid for `len` writes of `T`
+        // - mutable borrow is upheld by `&mut self`
+        unsafe { self.ptr.as_mut() }
+    }
+}
+
+impl<T: Debug> Debug for AlignedData<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        <[T] as Debug>::fmt(self, f)
+    }
+}
+
+impl<T: Clone> Clone for AlignedData<T> {
+    fn clone(&self) -> Self {
+        let mut new = Self::new_uninit(self.len());
+
+        assert_eq!(
+            self.len(),
+            new.len(),
+            "data length must be equal to clone safely"
+        );
+
+        for (new, old) in new.iter_mut().zip(self.iter()) {
+            new.write(old.clone());
+        }
+
+        // SAFETY:
+        // All values are properly initialized in the loop above.
+        unsafe { new.assume_init() }
+    }
+}
+
+impl<T> Drop for AlignedData<T> {
+    fn drop(&mut self) {
+        let layout = match NonZeroUsize::new(self.len()) {
+            Some(len) => Self::layout(len),
+            None => return, // nothing allocated, nothing to deallocate
+        };
+
+        // drop the contained T (i.e. dropping [T]), then dealloc
+
+        // SAFETY: explained per line below
+        unsafe {
+            // - `ptr` is valid for read/write
+            // - `ptr` is non-null and correctly aligned
+            // - If this is T: Pixel, it does not need drop glue
+            // - If this is any other T, we assume the initialization
+            //   made all values valid for dropping
+            // - we have exclusive access to the values contained in `ptr`
+            self.ptr.drop_in_place();
+
+            // - `ptr` was allocated via this (global) allocator
+            // - `layout` is equal to the one used for allocation (returned from
+            //   Self::layout for the same parameter `len`)
+            dealloc(self.ptr.as_ptr() as _, layout);
+        }
+    }
+}


### PR DESCRIPTION
Motivation:
- DIY version is small (<200 LoC vs 1500). normally not a big deal but there is a very high amount of unsafe code in the crate
- crate seems to be passively maintained ([two](https://github.com/sarah-quinones/aligned-vec/issues/26) [issues](https://github.com/sarah-quinones/aligned-vec/issues/27) regarding UB have been open for a while without response)[^1]
- slims down dependency tree a bit

[^1]: cases of UB should not concern v_frame