### PR TITLE
refactor: copy_from_slice per row

### DIFF
--- a/src/plane.rs
+++ b/src/plane.rs
@@ -254,7 +254,8 @@ where
     ///   this plane's `width * height`
     #[inline]
     pub fn copy_from_slice(&mut self, src: &[T]) -> Result<(), Error> {
-        let pixel_count = self.width().get() * self.height().get();
+        let width = self.width().get();
+        let pixel_count = width * self.height().get();
         if pixel_count != src.len() {
             return Err(Error::DataLength {
                 expected: pixel_count,
@@ -262,9 +263,10 @@ where
             });
         }
 
-        for (dest, src) in self.pixels_mut().zip(src.iter()) {
-            *dest = *src;
+        for (dst_row, src_row) in self.rows_mut().zip(src.chunks_exact(width)) {
+            dst_row.copy_from_slice(src_row);
         }
+
         Ok(())
     }
 


### PR DESCRIPTION
Found this while working on #51.

```
Benchmarking copy_from_slice_u8: Collecting 100 samples in estimated 5.0011 s (131k iterati
copy_from_slice_u8      time:   [38.180 µs 38.386 µs 38.580 µs]
                        change: [−95.645% −95.632% −95.620%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 18 outliers among 100 measurements (18.00%)
  4 (4.00%) low severe
  4 (4.00%) high mild
  10 (10.00%) high severe

Benchmarking copy_from_slice_u16: Collecting 100 samples in estimated 5.0325 s (71k iterati
copy_from_slice_u16     time:   [70.285 µs 70.848 µs 71.357 µs]
                        change: [−92.103% −92.069% −92.032%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 20 outliers among 100 measurements (20.00%)
  2 (2.00%) high mild
  18 (18.00%) high severe
```