### PR TITLE
refactor: manually implement Error trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ include = ["Cargo.toml", "README.md", "LICENSE", "src"]
 
 [dependencies]
 num-traits = "0.2.19"
-thiserror = "2.0.17"
 
 [features]
 padding_api = []

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,20 +13,19 @@
 //! handling various error conditions related to frame processing, data validation,
 //! and format compatibility.
 
-use thiserror::Error;
+use std::fmt;
 
 /// The error type for `v_frame` operations.
 ///
 /// This enum represents all possible error conditions that can occur during
 /// frame processing, including data validation errors, unsupported formats,
 /// and configuration mismatches.
-#[derive(Error, Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Error {
     /// Returned when the provided data buffer size does not match the expected size.
     ///
     /// This typically occurs when constructing a plane or frame from raw data with
     /// incorrect dimensions.
-    #[error("data length mismatch, expected {expected}, found {found}")]
     DataLength {
         /// The expected data length based on the provided dimensions
         expected: usize,
@@ -37,7 +36,6 @@ pub enum Error {
     /// Returned when attempting to create a frame with an unsupported bit depth.
     ///
     /// The library only supports bit depths from 8 to 16 bits inclusive.
-    #[error("only 8-16 bit frame data is supported, tried to create {found} bit frame")]
     UnsupportedBitDepth {
         /// The requested bit depth which triggered the error
         found: u8,
@@ -46,19 +44,16 @@ pub enum Error {
     /// Returned when the pixel data type does not match the specified bit depth.
     ///
     /// 8-bit frames must use `u8`, while 9-16 bit frames must use `u16`.
-    #[error("bit depth did not match requested data type")]
     DataTypeMismatch,
 
     /// Returned when frame dimensions are incompatible with the chroma subsampling format.
     ///
     /// For example, YUV420 requires even width and height, while YUV422 requires even width.
-    #[error("selected chroma subsampling does not support odd resolutions")]
     UnsupportedResolution,
 
     /// Returned when a plane's stride is smaller than its visible width.
     ///
     /// The stride must be at least as large as the width to accommodate each row of pixels.
-    #[error("provided stride {stride} was less than the visible width {width}")]
     InvalidStride {
         /// The stride which triggered the error
         stride: usize,
@@ -66,3 +61,29 @@ pub enum Error {
         width: usize,
     },
 }
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::DataLength { expected, found } => write!(
+                f,
+                "data length mismatch, expected {expected}, found {found}"
+            ),
+            Error::UnsupportedBitDepth { found } => write!(
+                f,
+                "only 8-16 bit frame data is supported, tried to create {found} bit frame"
+            ),
+            Error::DataTypeMismatch => write!(f, "bit depth did not match requested data type"),
+            Error::UnsupportedResolution => write!(
+                f,
+                "selected chroma subsampling does not support odd resolutions"
+            ),
+            Error::InvalidStride { stride, width } => write!(
+                f,
+                "provided stride {stride} was less than the visible width {width}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for Error {}

--- a/src/error.rs
+++ b/src/error.rs
@@ -63,6 +63,10 @@ pub enum Error {
 }
 
 impl fmt::Display for Error {
+    #[expect(
+        clippy::missing_inline_in_public_items,
+        reason = "string formatting often generates big code"
+    )]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::DataLength { expected, found } => write!(

--- a/src/frame/tests.rs
+++ b/src/frame/tests.rs
@@ -148,6 +148,9 @@ fn unsupported_bit_depth_too_high() {
         result,
         Err(Error::UnsupportedBitDepth { found: 17 })
     ));
+    assert!(
+        format!("{}", result.err().unwrap()).starts_with("only 8-16 bit frame data is supported,")
+    );
 }
 
 #[test]
@@ -160,6 +163,7 @@ fn data_type_mismatch_u8_with_10bit() {
         FrameBuilder::new(width, height, ChromaSubsampling::Yuv420, bit_depth).build::<u8>();
 
     assert!(matches!(result, Err(Error::DataTypeMismatch)));
+    assert!(format!("{}", result.err().unwrap()).starts_with("bit depth did not match"));
 }
 
 #[test]
@@ -184,6 +188,10 @@ fn yuv420_odd_width_resolution_error() {
         FrameBuilder::new(width, height, ChromaSubsampling::Yuv420, bit_depth).build::<u8>();
 
     assert!(matches!(result, Err(Error::UnsupportedResolution)));
+    assert!(
+        format!("{}", result.err().unwrap())
+            .starts_with("selected chroma subsampling does not support")
+    );
 }
 
 #[test]

--- a/src/plane/tests.rs
+++ b/src/plane/tests.rs
@@ -257,6 +257,7 @@ fn copy_from_slice_wrong_length() {
     let data = vec![1, 2, 3];
     let result = plane.copy_from_slice(&data);
     assert!(matches!(result, Err(Error::DataLength { .. })));
+    assert!(format!("{}", result.unwrap_err()).starts_with("data length mismatch,"));
 
     // Too long
     let data = vec![1, 2, 3, 4, 5, 6, 7, 8, 9];
@@ -477,6 +478,7 @@ fn copy_from_u8_slice_with_stride_invalid_stride() {
 
     let result = plane.copy_from_u8_slice_with_stride(&data, stride);
     assert!(matches!(result, Err(Error::InvalidStride { .. })));
+    assert!(format!("{}", result.unwrap_err()).starts_with("provided stride"));
 }
 
 #[test]


### PR DESCRIPTION
Removes the fairly heavy `syn` dependency from the crate tree and cuts us down to 5 compilation units (<1sec build times). I think that's worth a bit of boilerplate.