### PR TITLE
feat: allow uninitialized Plane<T>

### DIFF
--- a/benches/plane.rs
+++ b/benches/plane.rs
@@ -8,6 +8,11 @@ use std::hint::black_box;
 use std::num::{NonZeroU8, NonZeroUsize};
 use v_frame::{chroma::ChromaSubsampling, frame::FrameBuilder, plane::Plane};
 
+#[cfg(feature = "padding_api")]
+use std::mem::MaybeUninit;
+#[cfg(feature = "padding_api")]
+use v_frame::plane::PlaneGeometry;
+
 /// Standard HD resolution for benchmarks (1920x1080)
 const WIDTH: usize = 1920;
 const HEIGHT: usize = 1080;
@@ -36,6 +41,46 @@ fn create_plane_u16() -> Plane<u16> {
         .unwrap();
 
     frame.y_plane
+}
+
+#[cfg(feature = "padding_api")]
+/// Creates an uninitialized test plane for 8-bit benchmarks
+fn create_uninit_plane_u8() -> Plane<MaybeUninit<u8>> {
+    let width = NonZeroUsize::new(WIDTH).unwrap();
+    let height = NonZeroUsize::new(HEIGHT).unwrap();
+    let geometry = PlaneGeometry {
+        width,
+        height,
+        stride: width,
+        pad_left: 0,
+        pad_right: 0,
+        pad_top: 0,
+        pad_bottom: 0,
+        subsampling_x: NonZeroU8::new(1).unwrap(),
+        subsampling_y: NonZeroU8::new(1).unwrap(),
+    };
+
+    Plane::new_uninit(geometry)
+}
+
+#[cfg(feature = "padding_api")]
+/// Creates an uninitialized test plane for 10-bit benchmarks (using u16)
+fn create_uninit_plane_u16() -> Plane<MaybeUninit<u16>> {
+    let width = NonZeroUsize::new(WIDTH).unwrap();
+    let height = NonZeroUsize::new(HEIGHT).unwrap();
+    let geometry = PlaneGeometry {
+        width,
+        height,
+        stride: width,
+        pad_left: 0,
+        pad_right: 0,
+        pad_top: 0,
+        pad_bottom: 0,
+        subsampling_x: NonZeroU8::new(1).unwrap(),
+        subsampling_y: NonZeroU8::new(1).unwrap(),
+    };
+
+    Plane::new_uninit(geometry)
 }
 
 /// Creates source data for copy benchmarks (u8)
@@ -146,6 +191,42 @@ fn bench_copy_from_slice_u16(c: &mut Criterion) {
     });
 }
 
+#[cfg(feature = "padding_api")]
+fn bench_uninit_copy_from_slice_u8(c: &mut Criterion) {
+    let mut plane = create_uninit_plane_u8();
+    let source = create_source_u8();
+
+    c.bench_function("uninit_copy_from_slice_u8", |b| {
+        b.iter(|| {
+            for (dst, src) in black_box(&mut plane)
+                .data_mut()
+                .iter_mut()
+                .zip(black_box(&source))
+            {
+                dst.write(*src);
+            }
+        });
+    });
+}
+
+#[cfg(feature = "padding_api")]
+fn bench_uninit_copy_from_slice_u16(c: &mut Criterion) {
+    let mut plane = create_uninit_plane_u16();
+    let source = create_source_u16();
+
+    c.bench_function("uninit_copy_from_slice_u16", |b| {
+        b.iter(|| {
+            for (dst, src) in black_box(&mut plane)
+                .data_mut()
+                .iter_mut()
+                .zip(black_box(&source))
+            {
+                dst.write(*src);
+            }
+        });
+    });
+}
+
 fn bench_copy_from_u8_slice_u8(c: &mut Criterion) {
     let mut plane = create_plane_u8();
     let source = create_byte_source_u8();
@@ -204,6 +285,13 @@ fn bench_copy_from_u8_slice_with_stride_u16(c: &mut Criterion) {
     });
 }
 
+#[cfg(feature = "padding_api")]
+criterion_group!(
+    padding_api_benches,
+    bench_uninit_copy_from_slice_u8,
+    bench_uninit_copy_from_slice_u16,
+);
+
 criterion_group!(
     benches,
     bench_pixels_u8,
@@ -217,4 +305,9 @@ criterion_group!(
     bench_copy_from_u8_slice_with_stride_u8,
     bench_copy_from_u8_slice_with_stride_u16
 );
+
+#[cfg(not(feature = "padding_api"))]
 criterion_main!(benches);
+
+#[cfg(feature = "padding_api")]
+criterion_main!(benches, padding_api_benches);

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -33,6 +33,8 @@
 #[cfg(test)]
 mod tests;
 
+#[cfg(feature = "padding_api")]
+use std::mem::MaybeUninit;
 use std::num::{NonZeroU8, NonZeroUsize};
 
 mod aligned;
@@ -65,32 +67,14 @@ use crate::{error::Error, pixel::Pixel};
 /// - [`pixel()`](Plane::pixel) / [`pixel_mut()`](Plane::pixel_mut): Access individual pixels
 /// - [`pixels()`](Plane::pixels) / [`pixels_mut()`](Plane::pixels_mut): Iterate over all visible pixels
 #[derive(Debug, Clone)]
-pub struct Plane<T: Pixel> {
+pub struct Plane<T> {
     /// The underlying pixel data buffer, including padding.
     pub(crate) data: AlignedData<T>,
     /// Geometry information describing dimensions and padding.
     pub(crate) geometry: PlaneGeometry,
 }
 
-impl<T> Plane<T>
-where
-    T: Pixel,
-{
-    /// Creates a new plane with the given geometry, initialized with zero-valued pixels.
-    pub(crate) fn new(geometry: PlaneGeometry) -> Self {
-        let rows = geometry
-            .height
-            .saturating_add(geometry.pad_top)
-            .saturating_add(geometry.pad_bottom);
-
-        let pixels = rows.get() * geometry.stride.get();
-
-        Self {
-            data: AlignedData::new(pixels),
-            geometry,
-        }
-    }
-
+impl<T> Plane<T> {
     /// Returns the visible width of the plane in pixels
     #[inline]
     #[must_use]
@@ -103,6 +87,127 @@ where
     #[must_use]
     pub fn height(&self) -> NonZeroUsize {
         self.geometry.height
+    }
+
+    /// Returns the index for the first visible pixel in `data`.
+    ///
+    /// This is a low-level API intended only for functions that require access to the padding.
+    #[inline]
+    #[must_use]
+    #[cfg_attr(not(feature = "padding_api"), doc(hidden))]
+    pub fn data_origin(&self) -> usize {
+        self.geometry.stride.get() * self.geometry.pad_top + self.geometry.pad_left
+    }
+}
+
+#[cfg(feature = "padding_api")]
+impl<T> Plane<T> {
+    /// Creates a new plane with the given [`PlaneGeometry`] over unitialized memory.
+    ///
+    /// The underlying data needs to be initialized before this plane can be
+    /// converted and used in a [`Frame`][crate::frame::Frame].
+    ///
+    /// [`data_mut`][Plane::data_mut] can be used to initialize the underlying memory.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::num::{NonZeroU8, NonZeroUsize};
+    /// use v_frame::plane::{Plane, PlaneGeometry};
+    ///
+    /// let other_data = vec![42u8; 120 * 80];
+    ///
+    /// let geometry = PlaneGeometry {
+    ///     width: const { NonZeroUsize::new(120).unwrap() },
+    ///     height: const { NonZeroUsize::new(80).unwrap() },
+    ///     stride: const { NonZeroUsize::new(120).unwrap() },
+    ///     pad_left: 0,
+    ///     pad_right: 0,
+    ///     pad_top: 0,
+    ///     pad_bottom: 0,
+    ///     subsampling_x: const { NonZeroU8::new(1).unwrap() },
+    ///     subsampling_y: const { NonZeroU8::new(1).unwrap() },
+    /// };
+    ///
+    /// let mut plane = Plane::new_uninit(geometry);
+    /// assert_eq!(plane.data_mut().len(), other_data.len());
+    /// for (dst, src) in plane.data_mut().iter_mut().zip(other_data) {
+    ///     dst.write(src);
+    /// }
+    ///
+    /// // SAFETY: All values initialized above
+    /// let plane = unsafe { plane.assume_init() };
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn new_uninit(geometry: PlaneGeometry) -> Plane<MaybeUninit<T>> {
+        let rows = geometry.alloc_height();
+        let pixels = rows.saturating_mul(geometry.stride);
+
+        Plane {
+            data: AlignedData::new_uninit(pixels.get()),
+            geometry,
+        }
+    }
+
+    /// Returns the geometry of the current plane.
+    ///
+    /// This is a low-level API intended only for functions that require access to the padding.
+    #[inline]
+    #[must_use]
+    pub fn geometry(&self) -> PlaneGeometry {
+        self.geometry
+    }
+
+    /// Returns a reference to the current plane's data, including padding.
+    ///
+    /// This is a low-level API intended only for functions that require access to the padding.
+    #[inline]
+    #[must_use]
+    pub fn data(&self) -> &[T] {
+        &self.data
+    }
+
+    /// Returns a mutable reference to the current plane's data, including padding.
+    ///
+    /// This is a low-level API intended only for functions that require access to the padding.
+    #[inline]
+    #[must_use]
+    pub fn data_mut(&mut self) -> &mut [T] {
+        &mut self.data
+    }
+}
+
+#[cfg(feature = "padding_api")]
+impl<T> Plane<MaybeUninit<T>> {
+    /// Converts to `Plane<T>`.
+    ///
+    /// # Safety
+    /// It is up to the caller to ensure that all contained values are
+    /// initialized properly (see [`MaybeUninit::assume_init`]).
+    #[inline]
+    #[must_use]
+    pub unsafe fn assume_init(self) -> Plane<T> {
+        // SAFETY: Safety invariants are upheld by the caller.
+        let data = unsafe { self.data.assume_init() };
+
+        Plane {
+            data,
+            geometry: self.geometry,
+        }
+    }
+}
+
+impl<T: Pixel> Plane<T> {
+    /// Creates a new plane with the given geometry, initialized with zero-valued pixels.
+    pub(crate) fn new(geometry: PlaneGeometry) -> Self {
+        let rows = geometry.alloc_height();
+        let pixels = rows.get() * geometry.stride.get();
+
+        Self {
+            data: AlignedData::new(pixels),
+            geometry,
+        }
     }
 
     /// Returns a slice containing the visible pixels in
@@ -341,46 +446,6 @@ where
 
         Ok(())
     }
-
-    /// Returns the geometry of the current plane.
-    ///
-    /// This is a low-level API intended only for functions that require access to the padding.
-    #[inline]
-    #[must_use]
-    #[cfg(feature = "padding_api")]
-    pub fn geometry(&self) -> PlaneGeometry {
-        self.geometry
-    }
-
-    /// Returns a reference to the current plane's data, including padding.
-    ///
-    /// This is a low-level API intended only for functions that require access to the padding.
-    #[inline]
-    #[must_use]
-    #[cfg(feature = "padding_api")]
-    pub fn data(&self) -> &[T] {
-        &self.data
-    }
-
-    /// Returns a mutable reference to the current plane's data, including padding.
-    ///
-    /// This is a low-level API intended only for functions that require access to the padding.
-    #[inline]
-    #[must_use]
-    #[cfg(feature = "padding_api")]
-    pub fn data_mut(&mut self) -> &mut [T] {
-        &mut self.data
-    }
-
-    /// Returns the index for the first visible pixel in `data`.
-    ///
-    /// This is a low-level API intended only for functions that require access to the padding.
-    #[inline]
-    #[must_use]
-    #[cfg_attr(not(feature = "padding_api"), doc(hidden))]
-    pub fn data_origin(&self) -> usize {
-        self.geometry.stride.get() * self.geometry.pad_top + self.geometry.pad_left
-    }
 }
 
 /// Describes the geometry of a plane, including dimensions and padding.
@@ -392,7 +457,6 @@ where
 /// The `stride` represents the number of pixels per row in the data buffer,
 /// which is equal to `width + pad_left + pad_right`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(not(feature = "padding_api"), doc(hidden))]
 pub struct PlaneGeometry {
     /// Width of the visible area in pixels.
     pub width: NonZeroUsize,

--- a/src/plane/tests.rs
+++ b/src/plane/tests.rs
@@ -403,6 +403,26 @@ fn padding_api_data_access() {
     }
 }
 
+#[cfg(feature = "padding_api")]
+#[test]
+fn padding_api_data_access_uninit() {
+    let geometry = padded_geometry(2, 2, 1, 1, 1, 1);
+    let mut plane = Plane::new_uninit(geometry);
+
+    // Fill all data including padding
+    for (i, pixel) in plane.data_mut().iter_mut().enumerate() {
+        pixel.write(i as u8);
+    }
+
+    // SAFETY: Everything was initialized above.
+    let plane = unsafe { plane.assume_init() };
+
+    // Verify we can read it back
+    for (i, &pixel) in plane.data().iter().enumerate() {
+        assert_eq!(pixel, i as u8);
+    }
+}
+
 #[test]
 fn copy_from_u8_slice_with_stride_u8() {
     let geometry = simple_geometry(3, 2);


### PR DESCRIPTION
tl;dr:

- remove trait bound on `T` in `Plane<T>` (used to be `T: Pixel`)
- split `impl<T> Plane<T>` blocks
  - `T` -> basic accessors (width, height, data_origin)
  - `T` + `feature(padding_api)` -> raw data, geometry and MaybeUninit stuff
  - `T: Pixel` -> row and pixel iterators, copy_from_slice etc. (the "main" API)
- new uninit API
  - `fn Plane::new_uninit(geometry) -> Plane<MaybeUninit<T>>`
  - `fn unsafe Plane::assume_init(self: Plane<MaybeUninit<T>>) -> Plane<T>`

Performance-wise, the `bench_uninit_*` functions show that the naive implementation works well (bit quicker than `plane.copy_from_slice(data)`) IMHO.

Not 100% sure if this API should be incorporated into Frame/FrameBuilder too, it's probably fine like this. At least for now.