### PR TITLE
Add std traits to Frame, Plane, and AlignedData

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -99,7 +99,7 @@ use crate::{
 };
 
 /// Contains the data representing one YUV video frame.
-#[derive(Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Frame<T: Pixel> {
     /// The luma plane for this frame
     pub y_plane: Plane<T>,

--- a/src/pixel.rs
+++ b/src/pixel.rs
@@ -23,6 +23,7 @@
 //! - 9-16 bit frames must use `u16`
 
 use num_traits::PrimInt;
+use std::fmt::Debug;
 
 mod private {
     pub trait Sealed {}
@@ -55,7 +56,7 @@ mod private {
 /// i.e. using [`std::mem::zeroed`] must __not__ cause undefined behavior for
 /// implementing types.
 pub unsafe trait Pixel:
-    Copy + Clone + Default + Send + Sync + PrimInt + 'static + private::Sealed
+    Debug + Copy + Clone + Default + Send + Sync + PrimInt + 'static + private::Sealed
 {
 }
 

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -66,7 +66,7 @@ use crate::{error::Error, pixel::Pixel};
 /// - [`rows()`](Plane::rows) / [`rows_mut()`](Plane::rows_mut): Iterate over all visible rows
 /// - [`pixel()`](Plane::pixel) / [`pixel_mut()`](Plane::pixel_mut): Access individual pixels
 /// - [`pixels()`](Plane::pixels) / [`pixels_mut()`](Plane::pixels_mut): Iterate over all visible pixels
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Plane<T> {
     /// The underlying pixel data buffer, including padding.
     pub(crate) data: AlignedData<T>,

--- a/src/plane/aligned.rs
+++ b/src/plane/aligned.rs
@@ -133,7 +133,11 @@ impl<T> DerefMut for AlignedData<T> {
 
 impl<T: Debug> Debug for AlignedData<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        <[T] as Debug>::fmt(self, f)
+        if self.len() > 5 {
+            f.debug_list().entries(&self[..5]).finish_non_exhaustive()
+        } else {
+            f.debug_list().entries(&self[..]).finish()
+        }
     }
 }
 
@@ -261,10 +265,12 @@ mod tests {
         data[4] = 42;
         data[10] = 123;
 
-        assert_eq!(
-            format!("{data:?}"),
-            "[0, 0, 0, 0, 42, 0, 0, 0, 0, 0, 123, 0]"
-        );
+        assert_eq!(format!("{data:?}"), "[0, 0, 0, 0, 42, ..]");
+
+        let mut data = AlignedData::<u8>::new(3);
+        data[1] = 7;
+        // don't panic when len < 5
+        assert_eq!(format!("{data:?}"), "[0, 7, 0]");
     }
 
     #[test]

--- a/src/plane/aligned.rs
+++ b/src/plane/aligned.rs
@@ -16,6 +16,7 @@ const DATA_ALIGNMENT: usize = 1 << 3;
 #[cfg(not(target_arch = "wasm32"))]
 const DATA_ALIGNMENT: usize = 1 << 6;
 
+#[derive(PartialEq, Eq)]
 pub struct AlignedData<T> {
     ptr: NonNull<[T]>,
     _marker: PhantomData<T>,

--- a/src/plane/aligned.rs
+++ b/src/plane/aligned.rs
@@ -16,7 +16,6 @@ const DATA_ALIGNMENT: usize = 1 << 3;
 #[cfg(not(target_arch = "wasm32"))]
 const DATA_ALIGNMENT: usize = 1 << 6;
 
-#[derive(PartialEq, Eq)]
 pub struct AlignedData<T> {
     ptr: NonNull<[T]>,
     _marker: PhantomData<T>,
@@ -131,6 +130,14 @@ impl<T> DerefMut for AlignedData<T> {
         unsafe { self.ptr.as_mut() }
     }
 }
+
+impl<T: PartialEq<U>, U> PartialEq<AlignedData<U>> for AlignedData<T> {
+    fn eq(&self, other: &AlignedData<U>) -> bool {
+        <[T] as PartialEq<[U]>>::eq(self, other)
+    }
+}
+
+impl<T: Eq> Eq for AlignedData<T> {}
 
 impl<T: Debug> Debug for AlignedData<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -258,6 +265,53 @@ mod tests {
         // SAFETY: Initialized above.
         let data = unsafe { data.assume_init() };
         println!("{:?}", &*data);
+    }
+
+    #[test]
+    fn partialeq() {
+        let mut data = AlignedData::<u8>::new(8);
+        data[4] = 42;
+        data[6] = 123;
+
+        assert_eq!(data, data.clone());
+
+        let other_data = AlignedData::<u8>::new(8);
+        assert_ne!(data, other_data);
+
+        let mut other_data = data.clone();
+        other_data[2] = 50;
+        assert_ne!(data, other_data);
+
+        // does not compile:
+        // let u16_data = AlignedData::<u16>::new(10);
+        // assert_ne!(data, u16_data);
+    }
+
+    #[test]
+    fn partialeq_different_types() {
+        #[derive(Debug)]
+        struct Test(u8);
+
+        impl PartialEq<u8> for Test {
+            fn eq(&self, other: &u8) -> bool {
+                self.0.eq(other)
+            }
+        }
+
+        let mut data = AlignedData::<u8>::new(3);
+        data[0] = 42;
+
+        let mut test_data = AlignedData::<Test>::new_uninit(3);
+        test_data[0].write(Test(0));
+        test_data[1].write(Test(0));
+        test_data[2].write(Test(0));
+
+        // SAFETY: Fully initialized above.
+        let mut test_data = unsafe { test_data.assume_init() };
+        assert_ne!(test_data, data);
+
+        test_data[0] = Test(42);
+        assert_eq!(test_data, data);
     }
 
     #[test]

--- a/src/plane/tests.rs
+++ b/src/plane/tests.rs
@@ -355,6 +355,19 @@ fn plane_clone() {
 }
 
 #[test]
+fn plane_debug() {
+    let geometry = simple_geometry(3, 3);
+    let mut plane: Plane<u8> = Plane::new(geometry);
+
+    // Fill with test data
+    for (i, pixel) in plane.pixels_mut().enumerate() {
+        *pixel = i as u8;
+    }
+
+    println!("{plane:?}");
+}
+
+#[test]
 fn data_origin_no_padding() {
     let geometry = simple_geometry(4, 4);
     let plane: Plane<u8> = Plane::new(geometry);

--- a/src/plane/tests.rs
+++ b/src/plane/tests.rs
@@ -364,7 +364,23 @@ fn plane_debug() {
         *pixel = i as u8;
     }
 
-    println!("{plane:?}");
+    assert_eq!(
+        format!("{plane:?}"),
+        "Plane { \
+            data: [0, 1, 2, 3, 4, ..], \
+            geometry: PlaneGeometry { \
+                width: 3, \
+                height: 3, \
+                stride: 3, \
+                pad_left: 0, \
+                pad_right: 0, \
+                pad_top: 0, \
+                pad_bottom: 0, \
+                subsampling_x: 1, \
+                subsampling_y: 1 \
+            } \
+        }"
+    );
 }
 
 #[test]


### PR DESCRIPTION
In hindsight, making `<AlignedData<T> as Debug>::fmt` just print the entire slice was not a good idea. Truncate it if it's more than 5 pixels. This allows re-adding `Debug` to `Frame<T>` (it was removed in the great API rewrite of #44).

Also derive `PartialEq, Eq` for Frame, Plane, AlignedData. ~~(data is compared by pointer)~~ (see discussion below)

This should make upgrading easier for some consumers that use `println!("{frame:?}")` (e.g. av-metrics)