### PR TITLE
Add more API to PlaneGeometry

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -277,69 +277,29 @@ impl FrameBuilder {
             return Err(Error::DataTypeMismatch);
         }
 
-        let luma_stride = self
-            .width
-            .saturating_add(self.luma_padding_left)
-            .saturating_add(self.luma_padding_right);
-        let luma_geometry = PlaneGeometry {
-            width: self.width,
-            height: self.height,
-            stride: luma_stride,
-            pad_left: self.luma_padding_left,
-            pad_right: self.luma_padding_right,
-            pad_top: self.luma_padding_top,
-            pad_bottom: self.luma_padding_bottom,
-            subsampling_x: NonZeroU8::new(1).expect("non-zero constant"),
-            subsampling_y: NonZeroU8::new(1).expect("non-zero constant"),
-        };
-        if !self.subsampling.has_chroma() {
-            return Ok(Frame {
-                y_plane: Plane::new(luma_geometry),
-                u_plane: None,
-                v_plane: None,
-                subsampling: self.subsampling,
-                bit_depth: self.bit_depth,
-            });
-        }
-
-        let Some((chroma_width, chroma_height)) = self
-            .subsampling
-            .chroma_dimensions(self.width.get(), self.height.get())
-        else {
+        let Some(luma_geometry) = PlaneGeometry::new(
+            self.width.get(),
+            self.height.get(),
+            self.luma_padding_left,
+            self.luma_padding_right,
+            self.luma_padding_top,
+            self.luma_padding_bottom,
+            1,
+            1,
+        ) else {
             return Err(Error::UnsupportedResolution);
         };
 
-        let (ss_x, ss_y) = self.subsampling.subsample_ratio().expect("not monochrome");
-        if self.luma_padding_left % ss_x.get() as usize > 0
-            || self.luma_padding_right % ss_x.get() as usize > 0
-            || self.luma_padding_top % ss_y.get() as usize > 0
-            || self.luma_padding_bottom % ss_y.get() as usize > 0
-        {
-            return Err(Error::UnsupportedResolution);
-        }
-        let chroma_padding_left = self.luma_padding_left / ss_x.get() as usize;
-        let chroma_padding_right = self.luma_padding_right / ss_x.get() as usize;
-        let chroma_padding_top = self.luma_padding_top / ss_y.get() as usize;
-        let chroma_padding_bottom = self.luma_padding_bottom / ss_y.get() as usize;
-        let chroma_stride = chroma_width
-            .saturating_add(chroma_padding_left)
-            .saturating_add(chroma_padding_right);
-
-        let chroma_geometry = PlaneGeometry {
-            width: NonZeroUsize::new(chroma_width).expect("cannot be zero"),
-            height: NonZeroUsize::new(chroma_height).expect("cannot be zero"),
-            stride: NonZeroUsize::new(chroma_stride).expect("cannot be zero"),
-            pad_left: chroma_padding_left,
-            pad_right: chroma_padding_right,
-            pad_top: chroma_padding_top,
-            pad_bottom: chroma_padding_bottom,
-            subsampling_x: ss_x,
-            subsampling_y: ss_y,
+        let (u_plane, v_plane) = match luma_geometry.for_subsampling(self.subsampling) {
+            Ok(Some(g)) => (Some(Plane::new(g)), Some(Plane::new(g))),
+            Ok(None) => (None, None),
+            Err(_) => return Err(Error::UnsupportedResolution),
         };
+
         Ok(Frame {
             y_plane: Plane::new(luma_geometry),
-            u_plane: Some(Plane::new(chroma_geometry)),
-            v_plane: Some(Plane::new(chroma_geometry)),
+            u_plane,
+            v_plane,
             subsampling: self.subsampling,
             bit_depth: self.bit_depth,
         })

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -35,10 +35,13 @@ mod tests;
 
 #[cfg(feature = "padding_api")]
 use std::mem::MaybeUninit;
-use std::num::{NonZeroU8, NonZeroUsize};
+use std::num::NonZeroUsize;
 
 mod aligned;
 use aligned::AlignedData;
+
+mod geometry;
+pub use geometry::PlaneGeometry;
 
 use crate::{error::Error, pixel::Pixel};
 
@@ -445,50 +448,6 @@ impl<T: Pixel> Plane<T> {
         }
 
         Ok(())
-    }
-}
-
-/// Describes the geometry of a plane, including dimensions and padding.
-///
-/// This struct contains all the information needed to interpret the layout of
-/// a plane's data buffer, including the visible dimensions and the padding on
-/// all four sides.
-///
-/// The `stride` represents the number of pixels per row in the data buffer,
-/// which is equal to `width + pad_left + pad_right`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct PlaneGeometry {
-    /// Width of the visible area in pixels.
-    pub width: NonZeroUsize,
-    /// Height of the visible area in pixels.
-    pub height: NonZeroUsize,
-    /// Data stride (pixels per row in the buffer, including padding).
-    pub stride: NonZeroUsize,
-    /// Number of padding pixels on the left side.
-    pub pad_left: usize,
-    /// Number of padding pixels on the right side.
-    pub pad_right: usize,
-    /// Number of padding pixels on the top.
-    pub pad_top: usize,
-    /// Number of padding pixels on the bottom.
-    pub pad_bottom: usize,
-    /// The horizontal subsampling ratio of this plane compared to the luma plane
-    /// Will be 1 if no subsampling
-    pub subsampling_x: NonZeroU8,
-    /// The horizontal subsampling ratio of this plane compared to the luma plane
-    /// Will be 1 if no subsampling
-    pub subsampling_y: NonZeroU8,
-}
-
-impl PlaneGeometry {
-    /// Returns the total height of the plane, including padding
-    #[inline]
-    #[must_use]
-    #[cfg_attr(not(feature = "padding_api"), doc(hidden))]
-    pub fn alloc_height(&self) -> NonZeroUsize {
-        self.height
-            .saturating_add(self.pad_top)
-            .saturating_add(self.pad_bottom)
     }
 }
 

--- a/src/plane/geometry.rs
+++ b/src/plane/geometry.rs
@@ -1,5 +1,7 @@
 use std::num::{NonZeroU8, NonZeroUsize};
 
+use crate::chroma::ChromaSubsampling;
+
 /// Describes the geometry of a plane, including dimensions and padding.
 ///
 /// This struct contains all the information needed to interpret the layout of
@@ -33,6 +35,113 @@ pub struct PlaneGeometry {
 }
 
 impl PlaneGeometry {
+    /// Returns a new [`PlaneGeometry`] with the given dimensions, padding and subsampling.
+    ///
+    /// Will return `None` if:
+    /// - `width`, `height`, `subsampling_x` or `subsampling_y` are zero or
+    /// - the data stride would overflow a `usize`.
+    #[inline]
+    #[must_use]
+    #[expect(clippy::too_many_arguments)]
+    pub fn new(
+        width: usize,
+        height: usize,
+        pad_left: usize,
+        pad_right: usize,
+        pad_top: usize,
+        pad_bottom: usize,
+        subsampling_x: u8,
+        subsampling_y: u8,
+    ) -> Option<Self> {
+        let width = NonZeroUsize::new(width)?;
+        let height = NonZeroUsize::new(height)?;
+        let subsampling_x = NonZeroU8::new(subsampling_x)?;
+        let subsampling_y = NonZeroU8::new(subsampling_y)?;
+
+        let stride = width.checked_add(pad_left)?.checked_add(pad_right)?;
+
+        Some(Self {
+            width,
+            height,
+            stride,
+            pad_left,
+            pad_right,
+            pad_top,
+            pad_bottom,
+            subsampling_x,
+            subsampling_y,
+        })
+    }
+
+    /// Returns a new [`PlaneGeometry`] with the given dimensions, subsampling and zero padding.
+    ///
+    /// Returns `None` if `width`, `height`, `subsampling_x` or `subsampling_y` are zero.
+    #[inline]
+    #[must_use]
+    pub fn unpadded(
+        width: usize,
+        height: usize,
+        subsampling_x: u8,
+        subsampling_y: u8,
+    ) -> Option<Self> {
+        Self::new(width, height, 0, 0, 0, 0, subsampling_x, subsampling_y)
+    }
+
+    /// Returns a new [`PlaneGeometry`] based on `self` and according to `subsampling`.
+    ///
+    /// Returns:
+    /// - `Ok(None)` if the subsampling specifies no other planes (i.e. monochrome),
+    /// - `Ok(Some(g))` if `self` was successfully subsampled into a new geometry `g`,
+    /// - `Err(..)` if `self` could not be subsampled into a new geometry, for example
+    ///   due to `self` having an odd width or height.
+    ///
+    /// # Errors
+    ///
+    /// See [`SubsamplingError`].
+    #[inline]
+    pub fn for_subsampling(
+        self,
+        subsampling: ChromaSubsampling,
+    ) -> Result<Option<Self>, SubsamplingError> {
+        match subsampling {
+            ChromaSubsampling::Monochrome => Ok(None),
+            ChromaSubsampling::Yuv444 => Ok(Some(self)),
+            ChromaSubsampling::Yuv420 => self.subsampled::<2, 2>().map(Some),
+            ChromaSubsampling::Yuv422 => self.subsampled::<2, 1>().map(Some),
+        }
+    }
+
+    #[inline]
+    fn subsampled<const X: usize, const Y: usize>(self) -> Result<Self, SubsamplingError> {
+        let x = const { NonZeroUsize::new(X).expect("X nonzero") };
+        let y = const { NonZeroUsize::new(Y).expect("Y nonzero") };
+
+        if self.width.get() % x != 0
+            || self.height.get() % y != 0
+            || self.pad_left % x != 0
+            || self.pad_right % x != 0
+            || self.pad_top % y != 0
+            || self.pad_bottom % y != 0
+        {
+            return Err(SubsamplingError);
+        }
+
+        // X and Y must fit into the subsampling_* fields
+        const { assert!(X <= u8::MAX as usize && Y <= u8::MAX as usize) };
+
+        Self::new(
+            self.width.get() / x,
+            self.height.get() / y,
+            self.pad_left / x,
+            self.pad_right / x,
+            self.pad_top / y,
+            self.pad_bottom / y,
+            X as u8,
+            Y as u8,
+        )
+        .ok_or(SubsamplingError)
+    }
+
     /// Returns the total height of the plane, including padding
     #[inline]
     #[must_use]
@@ -41,5 +150,139 @@ impl PlaneGeometry {
         self.height
             .saturating_add(self.pad_top)
             .saturating_add(self.pad_bottom)
+    }
+}
+
+/// An error occurred when trying to create a subsampled geometry.
+///
+/// This usually means that there was an odd number of pixels in one of the dimensions
+/// that was being subsampled:
+/// - width, horizontal padding for [`ChromaSubsampling::Yuv422`] or [`ChromaSubsampling::Yuv420`]
+/// - height, vertical padding for [`ChromaSubsampling::Yuv420`]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SubsamplingError;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unpadded() {
+        assert!(PlaneGeometry::unpadded(0, 1080, 1, 1).is_none());
+        assert!(PlaneGeometry::unpadded(1920, 0, 1, 1).is_none());
+        assert!(PlaneGeometry::unpadded(1920, 1080, 0, 1).is_none());
+        assert!(PlaneGeometry::unpadded(1920, 1080, 1, 0).is_none());
+
+        let g = PlaneGeometry::unpadded(1920, 1080, 1, 1).expect("unpadded geometry works");
+        assert_eq!(g.width.get(), 1920);
+        assert_eq!(g.height.get(), 1080);
+        assert_eq!(g.stride, g.width);
+        assert_eq!(g.pad_left, 0);
+        assert_eq!(g.pad_right, 0);
+        assert_eq!(g.pad_top, 0);
+        assert_eq!(g.pad_bottom, 0);
+        assert_eq!(g.subsampling_x.get(), 1);
+        assert_eq!(g.subsampling_y.get(), 1);
+    }
+
+    #[test]
+    fn new() {
+        assert!(PlaneGeometry::new(0, 1080, 40, 30, 20, 10, 1, 1).is_none());
+        assert!(PlaneGeometry::new(1920, 0, 40, 30, 20, 10, 1, 1).is_none());
+        assert!(PlaneGeometry::new(1920, 1080, 40, 30, 20, 10, 0, 1).is_none());
+        assert!(PlaneGeometry::new(1920, 1080, 40, 30, 20, 10, 1, 0).is_none());
+
+        let g = PlaneGeometry::new(1920, 1080, 40, 30, 20, 10, 1, 1).expect("new geometry works");
+        assert_eq!(g.width.get(), 1920);
+        assert_eq!(g.height.get(), 1080);
+        assert_eq!(g.stride.get(), 1920 + 40 + 30);
+        assert_eq!(g.pad_left, 40);
+        assert_eq!(g.pad_right, 30);
+        assert_eq!(g.pad_top, 20);
+        assert_eq!(g.pad_bottom, 10);
+        assert_eq!(g.subsampling_x.get(), 1);
+        assert_eq!(g.subsampling_y.get(), 1);
+    }
+
+    #[test]
+    fn new_overflow() {
+        // Together, (width + pad_left + pad_right) overflow usize
+        assert!(PlaneGeometry::new(usize::MAX - 50, 1080, 30, 30, 0, 0, 1, 1).is_none());
+    }
+
+    #[test]
+    fn subsampled() {
+        let g = PlaneGeometry::new(1920, 1080, 40, 30, 20, 10, 1, 1).expect("can make geometry");
+
+        assert_eq!(g.for_subsampling(ChromaSubsampling::Monochrome), Ok(None));
+
+        let sub = g
+            .for_subsampling(ChromaSubsampling::Yuv444)
+            .expect("can 'subsample' to Yuv444")
+            .expect("subsampled plane exists for Yuv444");
+        assert_eq!(sub, g);
+
+        let sub = g
+            .for_subsampling(ChromaSubsampling::Yuv422)
+            .expect("can subsample to Yuv422")
+            .expect("subsampled plane exists for Yuv422");
+        assert_eq!(sub.width.get(), 960);
+        assert_eq!(sub.height.get(), 1080);
+        assert_eq!(sub.stride.get(), 960 + 20 + 15);
+        assert_eq!(sub.pad_left, 20);
+        assert_eq!(sub.pad_right, 15);
+        assert_eq!(sub.pad_top, 20);
+        assert_eq!(sub.pad_bottom, 10);
+        assert_eq!(sub.subsampling_x.get(), 2);
+        assert_eq!(sub.subsampling_y.get(), 1);
+
+        let sub = g
+            .for_subsampling(ChromaSubsampling::Yuv420)
+            .expect("can subsample to Yuv420")
+            .expect("subsampled plane exists for Yuv420");
+        assert_eq!(sub.width.get(), 960);
+        assert_eq!(sub.height.get(), 540);
+        assert_eq!(sub.stride.get(), 960 + 20 + 15);
+        assert_eq!(sub.pad_left, 20);
+        assert_eq!(sub.pad_right, 15);
+        assert_eq!(sub.pad_top, 10);
+        assert_eq!(sub.pad_bottom, 5);
+        assert_eq!(sub.subsampling_x.get(), 2);
+        assert_eq!(sub.subsampling_y.get(), 2);
+    }
+
+    #[test]
+    #[expect(clippy::unwrap_used)]
+    fn subsampled_reject() {
+        let g = PlaneGeometry::unpadded(1921, 1080, 1, 1).unwrap();
+        assert!(g.for_subsampling(ChromaSubsampling::Monochrome).is_ok());
+        assert!(g.for_subsampling(ChromaSubsampling::Yuv444).is_ok());
+        assert!(g.for_subsampling(ChromaSubsampling::Yuv422).is_err());
+        assert!(g.for_subsampling(ChromaSubsampling::Yuv420).is_err());
+
+        let g = PlaneGeometry::unpadded(1920, 1081, 1, 1).unwrap();
+        assert!(g.for_subsampling(ChromaSubsampling::Monochrome).is_ok());
+        assert!(g.for_subsampling(ChromaSubsampling::Yuv444).is_ok());
+        assert!(g.for_subsampling(ChromaSubsampling::Yuv422).is_ok());
+        assert!(g.for_subsampling(ChromaSubsampling::Yuv420).is_err());
+
+        let g = PlaneGeometry::unpadded(17, 41, 1, 1).unwrap();
+        assert!(g.for_subsampling(ChromaSubsampling::Monochrome).is_ok());
+        assert!(g.for_subsampling(ChromaSubsampling::Yuv444).is_ok());
+        assert!(g.for_subsampling(ChromaSubsampling::Yuv422).is_err());
+        assert!(g.for_subsampling(ChromaSubsampling::Yuv420).is_err());
+
+        // again with padding
+        let g = PlaneGeometry::new(1920, 1080, 10, 7, 40, 20, 1, 1).unwrap();
+        assert!(g.for_subsampling(ChromaSubsampling::Monochrome).is_ok());
+        assert!(g.for_subsampling(ChromaSubsampling::Yuv444).is_ok());
+        assert!(g.for_subsampling(ChromaSubsampling::Yuv422).is_err());
+        assert!(g.for_subsampling(ChromaSubsampling::Yuv420).is_err());
+
+        let g = PlaneGeometry::new(1920, 1080, 10, 10, 40, 15, 1, 1).unwrap();
+        assert!(g.for_subsampling(ChromaSubsampling::Monochrome).is_ok());
+        assert!(g.for_subsampling(ChromaSubsampling::Yuv444).is_ok());
+        assert!(g.for_subsampling(ChromaSubsampling::Yuv422).is_ok());
+        assert!(g.for_subsampling(ChromaSubsampling::Yuv420).is_err());
     }
 }

--- a/src/plane/geometry.rs
+++ b/src/plane/geometry.rs
@@ -1,0 +1,45 @@
+use std::num::{NonZeroU8, NonZeroUsize};
+
+/// Describes the geometry of a plane, including dimensions and padding.
+///
+/// This struct contains all the information needed to interpret the layout of
+/// a plane's data buffer, including the visible dimensions and the padding on
+/// all four sides.
+///
+/// The `stride` represents the number of pixels per row in the data buffer,
+/// which is equal to `width + pad_left + pad_right`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PlaneGeometry {
+    /// Width of the visible area in pixels.
+    pub width: NonZeroUsize,
+    /// Height of the visible area in pixels.
+    pub height: NonZeroUsize,
+    /// Data stride (pixels per row in the buffer, including padding).
+    pub stride: NonZeroUsize,
+    /// Number of padding pixels on the left side.
+    pub pad_left: usize,
+    /// Number of padding pixels on the right side.
+    pub pad_right: usize,
+    /// Number of padding pixels on the top.
+    pub pad_top: usize,
+    /// Number of padding pixels on the bottom.
+    pub pad_bottom: usize,
+    /// The horizontal subsampling ratio of this plane compared to the luma plane
+    /// Will be 1 if no subsampling
+    pub subsampling_x: NonZeroU8,
+    /// The horizontal subsampling ratio of this plane compared to the luma plane
+    /// Will be 1 if no subsampling
+    pub subsampling_y: NonZeroU8,
+}
+
+impl PlaneGeometry {
+    /// Returns the total height of the plane, including padding
+    #[inline]
+    #[must_use]
+    #[cfg_attr(not(feature = "padding_api"), doc(hidden))]
+    pub fn alloc_height(&self) -> NonZeroUsize {
+        self.height
+            .saturating_add(self.pad_top)
+            .saturating_add(self.pad_bottom)
+    }
+}

--- a/src/plane/tests.rs
+++ b/src/plane/tests.rs
@@ -10,23 +10,11 @@
 #![allow(clippy::unwrap_used, reason = "test file")]
 
 use super::*;
-use std::num::{NonZeroU8, NonZeroUsize};
+use std::num::NonZeroUsize;
 
 /// Helper function to create a simple plane geometry without padding
 fn simple_geometry(width: usize, height: usize) -> PlaneGeometry {
-    let width = NonZeroUsize::new(width).unwrap();
-    let height = NonZeroUsize::new(height).unwrap();
-    PlaneGeometry {
-        width,
-        height,
-        stride: width,
-        pad_left: 0,
-        pad_right: 0,
-        pad_top: 0,
-        pad_bottom: 0,
-        subsampling_x: NonZeroU8::new(1).unwrap(),
-        subsampling_y: NonZeroU8::new(1).unwrap(),
-    }
+    PlaneGeometry::unpadded(width, height, 1, 1).expect("can create simple geometry")
 }
 
 /// Helper function to create a plane geometry with padding
@@ -38,20 +26,10 @@ fn padded_geometry(
     pad_top: usize,
     pad_bottom: usize,
 ) -> PlaneGeometry {
-    let width = NonZeroUsize::new(width).unwrap();
-    let height = NonZeroUsize::new(height).unwrap();
-    let stride = NonZeroUsize::new(width.get() + pad_left + pad_right).unwrap();
-    PlaneGeometry {
-        width,
-        height,
-        stride,
-        pad_left,
-        pad_right,
-        pad_top,
-        pad_bottom,
-        subsampling_x: NonZeroU8::new(1).unwrap(),
-        subsampling_y: NonZeroU8::new(1).unwrap(),
-    }
+    PlaneGeometry::new(
+        width, height, pad_left, pad_right, pad_top, pad_bottom, 1, 1,
+    )
+    .expect("can create padded geometry")
 }
 
 #[test]

--- a/src/plane/tests.rs
+++ b/src/plane/tests.rs
@@ -10,7 +10,7 @@
 #![allow(clippy::unwrap_used, reason = "test file")]
 
 use super::*;
-use std::num::NonZeroUsize;
+use std::num::{NonZeroU8, NonZeroUsize};
 
 /// Helper function to create a simple plane geometry without padding
 fn simple_geometry(width: usize, height: usize) -> PlaneGeometry {


### PR DESCRIPTION
Manually creating PlaneGeometry is error-prone due to `stride` calculations and subsampling calculations being easy to mess up. Yes, the main usage should happen through `FrameBuilder` but the manual way doesn't need to be this unergonomic.