### PR TITLE
refactor!: disallow manual geometry creation

### DIFF
--- a/benches/plane.rs
+++ b/benches/plane.rs
@@ -46,40 +46,14 @@ fn create_plane_u16() -> Plane<u16> {
 #[cfg(feature = "padding_api")]
 /// Creates an uninitialized test plane for 8-bit benchmarks
 fn create_uninit_plane_u8() -> Plane<MaybeUninit<u8>> {
-    let width = NonZeroUsize::new(WIDTH).unwrap();
-    let height = NonZeroUsize::new(HEIGHT).unwrap();
-    let geometry = PlaneGeometry {
-        width,
-        height,
-        stride: width,
-        pad_left: 0,
-        pad_right: 0,
-        pad_top: 0,
-        pad_bottom: 0,
-        subsampling_x: NonZeroU8::new(1).unwrap(),
-        subsampling_y: NonZeroU8::new(1).unwrap(),
-    };
-
+    let geometry = PlaneGeometry::unpadded(WIDTH, HEIGHT, 1, 1).expect("can build geometry");
     Plane::new_uninit(geometry)
 }
 
 #[cfg(feature = "padding_api")]
 /// Creates an uninitialized test plane for 10-bit benchmarks (using u16)
 fn create_uninit_plane_u16() -> Plane<MaybeUninit<u16>> {
-    let width = NonZeroUsize::new(WIDTH).unwrap();
-    let height = NonZeroUsize::new(HEIGHT).unwrap();
-    let geometry = PlaneGeometry {
-        width,
-        height,
-        stride: width,
-        pad_left: 0,
-        pad_right: 0,
-        pad_top: 0,
-        pad_bottom: 0,
-        subsampling_x: NonZeroU8::new(1).unwrap(),
-        subsampling_y: NonZeroU8::new(1).unwrap(),
-    };
-
+    let geometry = PlaneGeometry::unpadded(WIDTH, HEIGHT, 1, 1).expect("can build geometry");
     Plane::new_uninit(geometry)
 }
 

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -120,17 +120,8 @@ impl<T> Plane<T> {
     ///
     /// let other_data = vec![42u8; 120 * 80];
     ///
-    /// let geometry = PlaneGeometry {
-    ///     width: const { NonZeroUsize::new(120).unwrap() },
-    ///     height: const { NonZeroUsize::new(80).unwrap() },
-    ///     stride: const { NonZeroUsize::new(120).unwrap() },
-    ///     pad_left: 0,
-    ///     pad_right: 0,
-    ///     pad_top: 0,
-    ///     pad_bottom: 0,
-    ///     subsampling_x: const { NonZeroU8::new(1).unwrap() },
-    ///     subsampling_y: const { NonZeroU8::new(1).unwrap() },
-    /// };
+    /// let geometry = PlaneGeometry::unpadded(120, 80, 1, 1)
+    ///     .expect("can build geometry");
     ///
     /// let mut plane = Plane::new_uninit(geometry);
     /// assert_eq!(plane.data_mut().len(), other_data.len());

--- a/src/plane/geometry.rs
+++ b/src/plane/geometry.rs
@@ -11,6 +11,7 @@ use crate::chroma::ChromaSubsampling;
 /// The `stride` represents the number of pixels per row in the data buffer,
 /// which is equal to `width + pad_left + pad_right`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[expect(clippy::manual_non_exhaustive)]
 pub struct PlaneGeometry {
     /// Width of the visible area in pixels.
     pub width: NonZeroUsize,
@@ -32,6 +33,9 @@ pub struct PlaneGeometry {
     /// The horizontal subsampling ratio of this plane compared to the luma plane
     /// Will be 1 if no subsampling
     pub subsampling_y: NonZeroU8,
+
+    // No manual instantiation outside of this module
+    _marker: (),
 }
 
 impl PlaneGeometry {
@@ -70,6 +74,7 @@ impl PlaneGeometry {
             pad_bottom,
             subsampling_x,
             subsampling_y,
+            _marker: (),
         })
     }
 

--- a/src/plane/tests.rs
+++ b/src/plane/tests.rs
@@ -355,7 +355,8 @@ fn plane_debug() {
                 pad_top: 0, \
                 pad_bottom: 0, \
                 subsampling_x: 1, \
-                subsampling_y: 1 \
+                subsampling_y: 1, \
+                _marker: () \
             } \
         }"
     );


### PR DESCRIPTION
Closes #61 for crate consumers. Note that `plane.geometry` is still `pub(crate)` so it's technically still possible for in-crate code to do something stupid like

```rs
let mut plane = make_plane();
plane.geometry.stride = NonZeroUsize::new(10000000).unwrap();

for row in plane.rows() {
    // -> this can be UB
    println!("{row:?}");
}
```

but I don't think that's something we need to worry much about.