### PR TITLE
refactor!: take zeroable usize in Plane API

### DIFF
--- a/benches/plane.rs
+++ b/benches/plane.rs
@@ -5,7 +5,6 @@
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use std::hint::black_box;
-use std::num::NonZeroUsize;
 use v_frame::{chroma::ChromaSubsampling, frame::FrameBuilder, plane::Plane};
 
 #[cfg(feature = "padding_api")]
@@ -223,13 +222,12 @@ fn bench_copy_from_u8_slice_with_stride_u8(c: &mut Criterion) {
     let mut plane = create_plane_u8();
     // Add 64 pixels of padding per row for a realistic strided scenario
     let stride = WIDTH + 64;
-    let stride_nz = NonZeroUsize::new(stride).unwrap();
     let source = create_strided_byte_source_u8(stride);
 
     c.bench_function("copy_from_u8_slice_with_stride_u8", |b| {
         b.iter(|| {
             black_box(&mut plane)
-                .copy_from_u8_slice_with_stride(black_box(&source), stride_nz)
+                .copy_from_u8_slice_with_stride(black_box(&source), stride)
                 .unwrap();
         });
     });
@@ -239,7 +237,7 @@ fn bench_copy_from_u8_slice_with_stride_u16(c: &mut Criterion) {
     let mut plane = create_plane_u16();
     // Add 64 pixels of padding per row for a realistic strided scenario
     let stride = WIDTH + 64;
-    let stride_bytes = NonZeroUsize::new(stride * 2).unwrap();
+    let stride_bytes = stride * 2;
     let source = create_strided_byte_source_u16(stride);
 
     c.bench_function("copy_from_u8_slice_with_stride_u16", |b| {

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -366,11 +366,7 @@ impl<T: Pixel> Plane<T> {
     ///   this plane's `width * height * bytes_per_pixel`
     #[inline]
     pub fn copy_from_u8_slice(&mut self, src: &[u8]) -> Result<(), Error> {
-        self.copy_from_u8_slice_with_stride(
-            src,
-            self.width()
-                .saturating_mul(NonZeroUsize::new(size_of::<T>()).expect("size can't be zero")),
-        )
+        self.copy_from_u8_slice_with_stride(src, self.width().get() * size_of::<T>())
     }
 
     /// Copies the data from `src` into this plane's visible pixels.
@@ -385,7 +381,7 @@ impl<T: Pixel> Plane<T> {
     pub fn copy_from_u8_slice_with_stride(
         &mut self,
         src: &[u8],
-        input_stride: NonZeroUsize,
+        stride: usize,
     ) -> Result<(), Error> {
         let byte_width = size_of::<T>();
         assert!(
@@ -393,14 +389,14 @@ impl<T: Pixel> Plane<T> {
             "unsupported pixel byte width: {byte_width}"
         );
 
-        if input_stride < self.width() {
+        if stride < self.width().get() {
             return Err(Error::InvalidStride {
-                stride: input_stride.get(),
+                stride,
                 width: self.width().get(),
             });
         }
 
-        let byte_count = input_stride.get() * self.height().get();
+        let byte_count = stride * self.height().get();
         if byte_count != src.len() {
             return Err(Error::DataLength {
                 expected: byte_count,
@@ -409,8 +405,6 @@ impl<T: Pixel> Plane<T> {
         }
 
         let width = self.width().get();
-        let stride = input_stride.get();
-
         if byte_width == 1 {
             // Fast path for u8 pixels
             for (row_idx, dest_row) in self.rows_mut().enumerate() {

--- a/src/plane/tests.rs
+++ b/src/plane/tests.rs
@@ -10,7 +10,6 @@
 #![allow(clippy::unwrap_used, reason = "test file")]
 
 use super::*;
-use std::num::NonZeroUsize;
 
 /// Helper function to create a simple plane geometry without padding
 fn simple_geometry(width: usize, height: usize) -> PlaneGeometry {
@@ -452,9 +451,8 @@ fn copy_from_u8_slice_with_stride_u8() {
     // Row 0: [10, 20, 30, PAD, PAD]
     // Row 1: [40, 50, 60, PAD, PAD]
     let data = vec![10, 20, 30, 99, 99, 40, 50, 60, 99, 99];
-    let stride = NonZeroUsize::new(5).unwrap();
 
-    plane.copy_from_u8_slice_with_stride(&data, stride).unwrap();
+    plane.copy_from_u8_slice_with_stride(&data, 5).unwrap();
 
     // Verify only the visible pixels were copied (padding should be ignored)
     assert_eq!(plane.pixel(0, 0).unwrap(), 10);
@@ -481,9 +479,8 @@ fn copy_from_u8_slice_with_stride_u16() {
         0x02, 0x01, 0x04, 0x03, 0xFF, 0xFF,  // Row 0
         0x06, 0x05, 0x08, 0x07, 0xFF, 0xFF,  // Row 1
     ];
-    let stride = NonZeroUsize::new(6).unwrap();
 
-    plane.copy_from_u8_slice_with_stride(&data, stride).unwrap();
+    plane.copy_from_u8_slice_with_stride(&data, 6).unwrap();
 
     // Verify only the visible pixels were copied
     assert_eq!(plane.pixel(0, 0).unwrap(), 0x0102);
@@ -499,9 +496,8 @@ fn copy_from_u8_slice_with_stride_equal_width() {
 
     // When stride == width, should delegate to copy_from_u8_slice
     let data = vec![1, 2, 3, 4, 5, 6];
-    let stride = NonZeroUsize::new(3).unwrap();
 
-    plane.copy_from_u8_slice_with_stride(&data, stride).unwrap();
+    plane.copy_from_u8_slice_with_stride(&data, 3).unwrap();
 
     let result: Vec<u8> = plane.pixels().collect();
     assert_eq!(result, data);
@@ -514,9 +510,8 @@ fn copy_from_u8_slice_with_stride_invalid_stride() {
 
     // Stride smaller than width is invalid
     let data = vec![1, 2, 3, 4, 5, 6, 7, 8];
-    let stride = NonZeroUsize::new(4).unwrap();
 
-    let result = plane.copy_from_u8_slice_with_stride(&data, stride);
+    let result = plane.copy_from_u8_slice_with_stride(&data, 4);
     assert!(matches!(result, Err(Error::InvalidStride { .. })));
     assert!(format!("{}", result.unwrap_err()).starts_with("provided stride"));
 }
@@ -528,9 +523,8 @@ fn copy_from_u8_slice_with_stride_wrong_length() {
 
     // Should need stride * height = 3 * 2 = 6 bytes
     let data = vec![1, 2, 3, 4]; // Only 4 bytes
-    let stride = NonZeroUsize::new(3).unwrap();
 
-    let result = plane.copy_from_u8_slice_with_stride(&data, stride);
+    let result = plane.copy_from_u8_slice_with_stride(&data, 3);
     assert!(matches!(result, Err(Error::DataLength { .. })));
 
     // u16 case: should need stride * height * 2 bytes
@@ -539,9 +533,8 @@ fn copy_from_u8_slice_with_stride_wrong_length() {
 
     // Should need 3 * 2 * 2 = 12 bytes
     let data = vec![1, 2, 3, 4, 5, 6]; // Only 6 bytes
-    let stride = NonZeroUsize::new(6).unwrap();
 
-    let result = plane.copy_from_u8_slice_with_stride(&data, stride);
+    let result = plane.copy_from_u8_slice_with_stride(&data, 6);
     assert!(matches!(result, Err(Error::DataLength { .. })));
 }
 


### PR DESCRIPTION
```rs
pub fn copy_from_u8_slice_with_stride(&mut self, src: &[u8], input_stride: NonZeroUsize) -> Result<(), Error>;
```

becomes

```rs
pub fn copy_from_u8_slice_with_stride(&mut self, src: &[u8], stride: usize) -> Result<(), Error>;
```

Same rationale as #63, I think returning NonZero types here for `width()` etc. is perfectly fine but taking a NonZero function parameter invites downstream boilerplate..