### PR TITLE
refactor!: split error types

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -22,17 +22,6 @@ use std::fmt;
 /// and configuration mismatches.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Error {
-    /// Returned when the provided data buffer size does not match the expected size.
-    ///
-    /// This typically occurs when constructing a plane or frame from raw data with
-    /// incorrect dimensions.
-    DataLength {
-        /// The expected data length based on the provided dimensions
-        expected: usize,
-        /// The actual length of the provided data array
-        found: usize,
-    },
-
     /// Returned when attempting to create a frame with an unsupported bit depth.
     ///
     /// The library only supports bit depths from 8 to 16 bits inclusive.
@@ -50,16 +39,6 @@ pub enum Error {
     ///
     /// For example, YUV420 requires even width and height, while YUV422 requires even width.
     UnsupportedResolution,
-
-    /// Returned when a plane's stride is smaller than its visible width.
-    ///
-    /// The stride must be at least as large as the width to accommodate each row of pixels.
-    InvalidStride {
-        /// The stride which triggered the error
-        stride: usize,
-        /// The visible width of the plane
-        width: usize,
-    },
 }
 
 impl fmt::Display for Error {
@@ -69,10 +48,6 @@ impl fmt::Display for Error {
     )]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::DataLength { expected, found } => write!(
-                f,
-                "data length mismatch, expected {expected}, found {found}"
-            ),
             Error::UnsupportedBitDepth { found } => write!(
                 f,
                 "only 8-16 bit frame data is supported, tried to create {found} bit frame"
@@ -81,10 +56,6 @@ impl fmt::Display for Error {
             Error::UnsupportedResolution => write!(
                 f,
                 "selected chroma subsampling does not support odd resolutions"
-            ),
-            Error::InvalidStride { stride, width } => write!(
-                f,
-                "provided stride {stride} was less than the visible width {width}"
             ),
         }
     }

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -31,7 +31,7 @@
 //! - Use `Frame<u16>` for high bit-depth (9-16 bit) video
 //!
 //! The builder validates that the pixel type matches the specified bit depth,
-//! returning [`Error::DataTypeMismatch`] if they don't align.
+//! returning [`FrameError::DataTypeMismatch`] if they don't align.
 //!
 //! # Padding
 //!
@@ -75,6 +75,9 @@
 //! .build::<u16>().unwrap();
 //! ```
 
+mod error;
+pub use error::FrameError;
+
 #[cfg(test)]
 mod tests;
 
@@ -82,7 +85,6 @@ use std::num::NonZeroU8;
 
 use crate::{
     chroma::ChromaSubsampling,
-    error::Error,
     pixel::Pixel,
     plane::{Plane, PlaneGeometry},
 };
@@ -232,13 +234,14 @@ impl FrameBuilder {
     /// Constructs a `Frame` from the current builder.
     ///
     /// # Errors
-    /// - Returns `Error::UnsupportedBitDepth` if the input bit depth is unsupported
+    /// - Returns `FrameError::UnsupportedBitDepth` if the input bit depth is unsupported
     ///   (currently 8-16 bit inputs are supported)
-    /// - Returns `Error::DataTypeMismatch` if the size of `T` does not match the input bit depth
-    /// - Returns `Error::UnsupportedResolution` if the resolution or padding dimensions
+    /// - Returns `FrameError::DataTypeMismatch` if the size of `T` does not match the
+    ///   input bit depth
+    /// - Returns `FrameError::UnsupportedResolution` if the resolution or padding dimensions
     ///   do not support the requested subsampling
     #[inline]
-    pub fn build<T: Pixel>(self) -> Result<Frame<T>, Error> {
+    pub fn build<T: Pixel>(self) -> Result<Frame<T>, FrameError> {
         let byte_width = const {
             let sz = size_of::<T>();
             assert!(sz > 0 && sz <= 2, "T must have a size of 1 or 2 bytes");
@@ -246,13 +249,13 @@ impl FrameBuilder {
         };
 
         if self.bit_depth < 8 || self.bit_depth > 16 {
-            return Err(Error::UnsupportedBitDepth {
+            return Err(FrameError::UnsupportedBitDepth {
                 found: self.bit_depth,
             });
         }
 
         if (byte_width == 1 && self.bit_depth != 8) || (byte_width == 2 && self.bit_depth <= 8) {
-            return Err(Error::DataTypeMismatch);
+            return Err(FrameError::DataTypeMismatch);
         }
 
         let Some(luma_geometry) = PlaneGeometry::new(
@@ -265,13 +268,13 @@ impl FrameBuilder {
             1,
             1,
         ) else {
-            return Err(Error::UnsupportedResolution);
+            return Err(FrameError::UnsupportedResolution);
         };
 
         let (u_plane, v_plane) = match luma_geometry.for_subsampling(self.subsampling) {
             Ok(Some(g)) => (Some(Plane::new(g)), Some(Plane::new(g))),
             Ok(None) => (None, None),
-            Err(_) => return Err(Error::UnsupportedResolution),
+            Err(_) => return Err(FrameError::UnsupportedResolution),
         };
 
         Ok(Frame {
@@ -280,7 +283,7 @@ impl FrameBuilder {
             v_plane,
             subsampling: self.subsampling,
             bit_depth: NonZeroU8::new(self.bit_depth)
-                .ok_or(Error::UnsupportedBitDepth { found: 0 })?,
+                .ok_or(FrameError::UnsupportedBitDepth { found: 0 })?,
         })
     }
 }

--- a/src/frame/error.rs
+++ b/src/frame/error.rs
@@ -7,21 +7,13 @@
 // Media Patent License 1.0 was not distributed with this source code in the
 // PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 
-//! Error types for the `v_frame` crate.
-//!
-//! This module defines the error types used throughout the `v_frame` crate for
-//! handling various error conditions related to frame processing, data validation,
-//! and format compatibility.
-
 use std::fmt;
 
-/// The error type for `v_frame` operations.
-///
 /// This enum represents all possible error conditions that can occur during
-/// frame processing, including data validation errors, unsupported formats,
+/// frame creation, including data validation errors, unsupported formats,
 /// and configuration mismatches.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum Error {
+pub enum FrameError {
     /// Returned when attempting to create a frame with an unsupported bit depth.
     ///
     /// The library only supports bit depths from 8 to 16 bits inclusive.
@@ -41,19 +33,18 @@ pub enum Error {
     UnsupportedResolution,
 }
 
-impl fmt::Display for Error {
-    #[expect(
-        clippy::missing_inline_in_public_items,
-        reason = "string formatting often generates big code"
-    )]
+impl fmt::Display for FrameError {
+    #[expect(clippy::missing_inline_in_public_items)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::UnsupportedBitDepth { found } => write!(
+            Self::UnsupportedBitDepth { found } => write!(
                 f,
                 "only 8-16 bit frame data is supported, tried to create {found} bit frame"
             ),
-            Error::DataTypeMismatch => write!(f, "bit depth did not match requested data type"),
-            Error::UnsupportedResolution => write!(
+            Self::DataTypeMismatch => {
+                write!(f, "bit depth did not match requested data type")
+            }
+            Self::UnsupportedResolution => write!(
                 f,
                 "selected chroma subsampling does not support odd resolutions"
             ),
@@ -61,4 +52,4 @@ impl fmt::Display for Error {
     }
 }
 
-impl std::error::Error for Error {}
+impl std::error::Error for FrameError {}

--- a/src/frame/tests.rs
+++ b/src/frame/tests.rs
@@ -140,7 +140,7 @@ fn unsupported_bit_depth_too_low() {
 
     assert!(matches!(
         result,
-        Err(Error::UnsupportedBitDepth { found: 7 })
+        Err(FrameError::UnsupportedBitDepth { found: 7 })
     ));
 }
 
@@ -150,7 +150,7 @@ fn unsupported_bit_depth_too_high() {
 
     assert!(matches!(
         result,
-        Err(Error::UnsupportedBitDepth { found: 17 })
+        Err(FrameError::UnsupportedBitDepth { found: 17 })
     ));
     assert!(
         format!("{}", result.err().unwrap()).starts_with("only 8-16 bit frame data is supported,")
@@ -161,7 +161,7 @@ fn unsupported_bit_depth_too_high() {
 fn data_type_mismatch_u8_with_10bit() {
     let result = FrameBuilder::new(1920, 1080, ChromaSubsampling::Yuv420, 10).build::<u8>();
 
-    assert!(matches!(result, Err(Error::DataTypeMismatch)));
+    assert!(matches!(result, Err(FrameError::DataTypeMismatch)));
     assert!(format!("{}", result.err().unwrap()).starts_with("bit depth did not match"));
 }
 
@@ -169,14 +169,14 @@ fn data_type_mismatch_u8_with_10bit() {
 fn data_type_mismatch_u16_with_8bit() {
     let result = FrameBuilder::new(1920, 1080, ChromaSubsampling::Yuv420, 8).build::<u16>();
 
-    assert!(matches!(result, Err(Error::DataTypeMismatch)));
+    assert!(matches!(result, Err(FrameError::DataTypeMismatch)));
 }
 
 #[test]
 fn yuv420_odd_width_resolution_error() {
     let result = FrameBuilder::new(1921, 1080, ChromaSubsampling::Yuv420, 8).build::<u8>();
 
-    assert!(matches!(result, Err(Error::UnsupportedResolution)));
+    assert!(matches!(result, Err(FrameError::UnsupportedResolution)));
     assert!(
         format!("{}", result.err().unwrap())
             .starts_with("selected chroma subsampling does not support")
@@ -187,14 +187,14 @@ fn yuv420_odd_width_resolution_error() {
 fn yuv420_odd_height_resolution_error() {
     let result = FrameBuilder::new(1920, 1081, ChromaSubsampling::Yuv420, 8).build::<u8>();
 
-    assert!(matches!(result, Err(Error::UnsupportedResolution)));
+    assert!(matches!(result, Err(FrameError::UnsupportedResolution)));
 }
 
 #[test]
 fn yuv422_odd_width_resolution_error() {
     let result = FrameBuilder::new(1921, 1080, ChromaSubsampling::Yuv422, 8).build::<u8>();
 
-    assert!(matches!(result, Err(Error::UnsupportedResolution)));
+    assert!(matches!(result, Err(FrameError::UnsupportedResolution)));
 }
 
 #[test]
@@ -235,7 +235,7 @@ fn padding_not_aligned_to_subsampling_yuv420() {
         .luma_padding_left(15)
         .build::<u8>();
 
-    assert!(matches!(result, Err(Error::UnsupportedResolution)));
+    assert!(matches!(result, Err(FrameError::UnsupportedResolution)));
 }
 
 #[test]
@@ -245,7 +245,7 @@ fn padding_not_aligned_to_subsampling_yuv422() {
         .luma_padding_left(15)
         .build::<u8>();
 
-    assert!(matches!(result, Err(Error::UnsupportedResolution)));
+    assert!(matches!(result, Err(FrameError::UnsupportedResolution)));
 }
 
 #[test]

--- a/src/frame/tests.rs
+++ b/src/frame/tests.rs
@@ -135,6 +135,15 @@ fn monochrome_no_chroma_planes() {
 }
 
 #[test]
+fn unsupported_resolution_zero_width_height() {
+    let result = FrameBuilder::new(0, 1080, ChromaSubsampling::Yuv420, 8).build::<u8>();
+    assert_eq!(result, Err(FrameError::UnsupportedResolution));
+
+    let result = FrameBuilder::new(1920, 0, ChromaSubsampling::Yuv422, 8).build::<u8>();
+    assert_eq!(result, Err(FrameError::UnsupportedResolution));
+}
+
+#[test]
 fn unsupported_bit_depth_too_low() {
     let result = FrameBuilder::new(1920, 1080, ChromaSubsampling::Yuv420, 7).build::<u8>();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,6 @@
 //! ```
 
 pub mod chroma;
-pub mod error;
 pub mod frame;
 pub mod pixel;
 pub mod plane;

--- a/src/pixel.rs
+++ b/src/pixel.rs
@@ -48,7 +48,7 @@ mod private {
 /// - Frames with 9-16 bit depth can only be created with `T = u16`
 ///
 /// Attempting to create a frame with a mismatched type will result in
-/// [`Error::DataTypeMismatch`](crate::error::Error::DataTypeMismatch).
+/// [`FrameError::DataTypeMismatch`][crate::frame::FrameError::DataTypeMismatch].
 ///
 /// # Safety
 ///

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -30,6 +30,9 @@
 //! To ensure safety, planes must be instantiated by building a [`Frame`](crate::frame::Frame)
 //! through the [`FrameBuilder`](crate::frame::FrameBuilder) interface.
 
+mod error;
+pub use error::CopyError;
+
 #[cfg(test)]
 mod tests;
 
@@ -43,7 +46,7 @@ use aligned::AlignedData;
 mod geometry;
 pub use geometry::PlaneGeometry;
 
-use crate::{error::Error, pixel::Pixel};
+use crate::pixel::Pixel;
 
 /// A two-dimensional plane of pixel data with optional padding.
 ///
@@ -334,14 +337,14 @@ impl<T: Pixel> Plane<T> {
     /// Copies the data from `src` into this plane's visible pixels.
     ///
     /// # Errors
-    /// - Returns `Error::Datalength` if the length of `src` does not match
+    /// - Returns `CopyError::DataLength` if the length of `src` does not match
     ///   this plane's `width * height`
     #[inline]
-    pub fn copy_from_slice(&mut self, src: &[T]) -> Result<(), Error> {
+    pub fn copy_from_slice(&mut self, src: &[T]) -> Result<(), CopyError> {
         let width = self.width().get();
         let pixel_count = width * self.height().get();
         if pixel_count != src.len() {
-            return Err(Error::DataLength {
+            return Err(CopyError::DataLength {
                 expected: pixel_count,
                 found: src.len(),
             });
@@ -362,10 +365,10 @@ impl<T: Pixel> Plane<T> {
     /// this is equivalent to `copy_from_slice`.
     ///
     /// # Errors
-    /// - Returns `Error::Datalength` if the length of `src` does not match
+    /// - Returns `CopyError::DataLength` if the length of `src` does not match
     ///   this plane's `width * height * bytes_per_pixel`
     #[inline]
-    pub fn copy_from_u8_slice(&mut self, src: &[u8]) -> Result<(), Error> {
+    pub fn copy_from_u8_slice(&mut self, src: &[u8]) -> Result<(), CopyError> {
         self.copy_from_u8_slice_with_stride(src, self.width().get() * size_of::<T>())
     }
 
@@ -374,15 +377,15 @@ impl<T: Pixel> Plane<T> {
     /// The `input_stride` must be in bytes.
     ///
     /// # Errors
-    /// - Returns `Error::Datalength` if the length of `src` does not match
+    /// - Returns `CopyError::DataLength` if the length of `src` does not match
     ///   this plane's `width * height * bytes_per_pixel`
-    /// - Returns `Error::InvalidStride` if the stride is shorter than the visible width
+    /// - Returns `CopyError::InvalidStride` if the stride is shorter than the visible width
     #[inline]
     pub fn copy_from_u8_slice_with_stride(
         &mut self,
         src: &[u8],
         stride: usize,
-    ) -> Result<(), Error> {
+    ) -> Result<(), CopyError> {
         let byte_width = size_of::<T>();
         assert!(
             byte_width <= 2,
@@ -390,7 +393,7 @@ impl<T: Pixel> Plane<T> {
         );
 
         if stride < self.width().get() {
-            return Err(Error::InvalidStride {
+            return Err(CopyError::InvalidStride {
                 stride,
                 width: self.width().get(),
             });
@@ -398,7 +401,7 @@ impl<T: Pixel> Plane<T> {
 
         let byte_count = stride * self.height().get();
         if byte_count != src.len() {
-            return Err(Error::DataLength {
+            return Err(CopyError::DataLength {
                 expected: byte_count,
                 found: src.len(),
             });

--- a/src/plane/error.rs
+++ b/src/plane/error.rs
@@ -1,0 +1,53 @@
+// Copyright (c) 2025, The rav1e contributors. All rights reserved
+//
+// This source code is subject to the terms of the BSD 2 Clause License and
+// the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+// was not distributed with this source code in the LICENSE file, you can
+// obtain it at www.aomedia.org/license/software. If the Alliance for Open
+// Media Patent License 1.0 was not distributed with this source code in the
+// PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+
+use std::fmt;
+
+/// An error representing why data couldn't be copied into a Plane.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CopyError {
+    /// Returned when the provided data buffer size does not match the expected size.
+    ///
+    /// This typically occurs when constructing a plane or frame from raw data with
+    /// incorrect dimensions.
+    DataLength {
+        /// The expected (i.e. destination) data length based on the provided dimensions.
+        expected: usize,
+        /// The actual (i.e. source) length of the provided data.
+        found: usize,
+    },
+
+    /// Returned when a plane's stride is smaller than its visible width.
+    ///
+    /// The stride must be at least as large as the width to accommodate each row of pixels.
+    InvalidStride {
+        /// The stride which triggered the error.
+        stride: usize,
+        /// The visible width of the plane.
+        width: usize,
+    },
+}
+
+impl fmt::Display for CopyError {
+    #[expect(clippy::missing_inline_in_public_items)]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DataLength { expected, found } => write!(
+                f,
+                "data length mismatch, expected {expected}, found {found}"
+            ),
+            Self::InvalidStride { stride, width } => write!(
+                f,
+                "provided stride {stride} was less than the visible width {width}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for CopyError {}

--- a/src/plane/tests.rs
+++ b/src/plane/tests.rs
@@ -233,13 +233,13 @@ fn copy_from_slice_wrong_length() {
     // Too short
     let data = vec![1, 2, 3];
     let result = plane.copy_from_slice(&data);
-    assert!(matches!(result, Err(Error::DataLength { .. })));
+    assert!(matches!(result, Err(CopyError::DataLength { .. })));
     assert!(format!("{}", result.unwrap_err()).starts_with("data length mismatch,"));
 
     // Too long
     let data = vec![1, 2, 3, 4, 5, 6, 7, 8, 9];
     let result = plane.copy_from_slice(&data);
-    assert!(matches!(result, Err(Error::DataLength { .. })));
+    assert!(matches!(result, Err(CopyError::DataLength { .. })));
 }
 
 #[test]
@@ -277,7 +277,7 @@ fn copy_from_u8_slice_wrong_length() {
     // Should need 8 bytes (4 pixels * 2 bytes each)
     let data = vec![1, 2, 3, 4]; // Only 4 bytes
     let result = plane.copy_from_u8_slice(&data);
-    assert!(matches!(result, Err(Error::DataLength { .. })));
+    assert!(matches!(result, Err(CopyError::DataLength { .. })));
 }
 
 #[test]
@@ -512,7 +512,7 @@ fn copy_from_u8_slice_with_stride_invalid_stride() {
     let data = vec![1, 2, 3, 4, 5, 6, 7, 8];
 
     let result = plane.copy_from_u8_slice_with_stride(&data, 4);
-    assert!(matches!(result, Err(Error::InvalidStride { .. })));
+    assert!(matches!(result, Err(CopyError::InvalidStride { .. })));
     assert!(format!("{}", result.unwrap_err()).starts_with("provided stride"));
 }
 
@@ -525,7 +525,7 @@ fn copy_from_u8_slice_with_stride_wrong_length() {
     let data = vec![1, 2, 3, 4]; // Only 4 bytes
 
     let result = plane.copy_from_u8_slice_with_stride(&data, 3);
-    assert!(matches!(result, Err(Error::DataLength { .. })));
+    assert!(matches!(result, Err(CopyError::DataLength { .. })));
 
     // u16 case: should need stride * height * 2 bytes
     let geometry = simple_geometry(2, 2);
@@ -535,7 +535,7 @@ fn copy_from_u8_slice_with_stride_wrong_length() {
     let data = vec![1, 2, 3, 4, 5, 6]; // Only 6 bytes
 
     let result = plane.copy_from_u8_slice_with_stride(&data, 6);
-    assert!(matches!(result, Err(Error::DataLength { .. })));
+    assert!(matches!(result, Err(CopyError::DataLength { .. })));
 }
 
 #[test]


### PR DESCRIPTION
The errors can be unambiguously separated into "something went wrong when copying into a Plane" and "this is not valid for a Frame", so I did.