### PR TITLE
chore: add multimedia::video crate category

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "v_frame"
 version = "0.5.2"
 rust-version = "1.85.0"
 description = "Video Frame data structures, originally part of rav1e"
+categories = ["multimedia::video"]
 license = "BSD-2-Clause"
 edition = "2024"
 repository = "https://github.com/rust-av/v_frame"


### PR DESCRIPTION
Up to 5 are allowed, must be from [this list](https://crates.io/category_slugs). I think this one is a no-brainer, feel free to add more if you want.