### PR TITLE
refactor!: make PlaneGeometry fields private

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -52,13 +52,13 @@
 //!     .unwrap();
 //!
 //! // Access the planes
-//! assert_eq!(frame.y_plane.width().get(), 1920);
-//! assert_eq!(frame.y_plane.height().get(), 1080);
+//! assert_eq!(frame.y_plane.width(), 1920);
+//! assert_eq!(frame.y_plane.height(), 1080);
 //!
 //! // Chroma planes are half size for YUV420
 //! let u_plane = frame.u_plane.as_ref().unwrap();
-//! assert_eq!(u_plane.width().get(), 960);
-//! assert_eq!(u_plane.height().get(), 540);
+//! assert_eq!(u_plane.width(), 960);
+//! assert_eq!(u_plane.height(), 540);
 //! ```
 //!
 //! # Creating Frames with Padding

--- a/src/frame/tests.rs
+++ b/src/frame/tests.rs
@@ -56,8 +56,8 @@ fn basic_8bit_frame() {
         .build::<u8>()
         .unwrap();
 
-    assert_eq!(frame.y_plane.width().get(), 1920);
-    assert_eq!(frame.y_plane.height().get(), 1080);
+    assert_eq!(frame.y_plane.width(), 1920);
+    assert_eq!(frame.y_plane.height(), 1080);
     assert_eq!(frame.bit_depth.get(), 8);
     assert_eq!(frame.subsampling, ChromaSubsampling::Yuv420);
 }
@@ -68,8 +68,8 @@ fn basic_10bit_frame() {
         .build::<u16>()
         .unwrap();
 
-    assert_eq!(frame.y_plane.width().get(), 3840);
-    assert_eq!(frame.y_plane.height().get(), 2160);
+    assert_eq!(frame.y_plane.width(), 3840);
+    assert_eq!(frame.y_plane.height(), 2160);
     assert_eq!(frame.bit_depth.get(), 10);
 }
 
@@ -83,10 +83,10 @@ fn yuv420_chroma_dimensions() {
     let v_plane = frame.v_plane.as_ref().unwrap();
 
     // YUV420 has chroma planes at half width and half height
-    assert_eq!(u_plane.width().get(), 960);
-    assert_eq!(u_plane.height().get(), 540);
-    assert_eq!(v_plane.width().get(), 960);
-    assert_eq!(v_plane.height().get(), 540);
+    assert_eq!(u_plane.width(), 960);
+    assert_eq!(u_plane.height(), 540);
+    assert_eq!(v_plane.width(), 960);
+    assert_eq!(v_plane.height(), 540);
 }
 
 #[test]
@@ -99,10 +99,10 @@ fn yuv422_chroma_dimensions() {
     let v_plane = frame.v_plane.as_ref().unwrap();
 
     // YUV422 has chroma planes at half width and full height
-    assert_eq!(u_plane.width().get(), 960);
-    assert_eq!(u_plane.height().get(), 1080);
-    assert_eq!(v_plane.width().get(), 960);
-    assert_eq!(v_plane.height().get(), 1080);
+    assert_eq!(u_plane.width(), 960);
+    assert_eq!(u_plane.height(), 1080);
+    assert_eq!(v_plane.width(), 960);
+    assert_eq!(v_plane.height(), 1080);
 }
 
 #[test]
@@ -115,10 +115,10 @@ fn yuv444_chroma_dimensions() {
     let v_plane = frame.v_plane.as_ref().unwrap();
 
     // YUV444 has chroma planes at full resolution
-    assert_eq!(u_plane.width().get(), 1920);
-    assert_eq!(u_plane.height().get(), 1080);
-    assert_eq!(v_plane.width().get(), 1920);
-    assert_eq!(v_plane.height().get(), 1080);
+    assert_eq!(u_plane.width(), 1920);
+    assert_eq!(u_plane.height(), 1080);
+    assert_eq!(v_plane.width(), 1920);
+    assert_eq!(v_plane.height(), 1080);
 }
 
 #[test]
@@ -127,8 +127,8 @@ fn monochrome_no_chroma_planes() {
         .build::<u8>()
         .unwrap();
 
-    assert_eq!(frame.y_plane.width().get(), 1920);
-    assert_eq!(frame.y_plane.height().get(), 1080);
+    assert_eq!(frame.y_plane.width(), 1920);
+    assert_eq!(frame.y_plane.height(), 1080);
     assert!(frame.u_plane.is_none());
     assert!(frame.v_plane.is_none());
     assert_eq!(frame.subsampling, ChromaSubsampling::Monochrome);
@@ -217,8 +217,8 @@ fn frame_with_luma_padding() {
         .unwrap();
 
     // Visible dimensions should remain unchanged
-    assert_eq!(frame.y_plane.width().get(), 1920);
-    assert_eq!(frame.y_plane.height().get(), 1080);
+    assert_eq!(frame.y_plane.width(), 1920);
+    assert_eq!(frame.y_plane.height(), 1080);
 }
 
 #[test]
@@ -233,8 +233,8 @@ fn chroma_padding_derived_from_luma_yuv420() {
 
     // For YUV420, chroma padding should be half of luma padding
     let u_plane = frame.u_plane.as_ref().unwrap();
-    assert_eq!(u_plane.width().get(), 960); // chroma width
-    assert_eq!(u_plane.height().get(), 540); // chroma height
+    assert_eq!(u_plane.width(), 960); // chroma width
+    assert_eq!(u_plane.height(), 540); // chroma height
 }
 
 #[test]
@@ -321,12 +321,12 @@ fn small_resolution() {
         .build::<u8>()
         .unwrap();
 
-    assert_eq!(frame.y_plane.width().get(), 2);
-    assert_eq!(frame.y_plane.height().get(), 2);
+    assert_eq!(frame.y_plane.width(), 2);
+    assert_eq!(frame.y_plane.height(), 2);
 
     let u_plane = frame.u_plane.as_ref().unwrap();
-    assert_eq!(u_plane.width().get(), 1);
-    assert_eq!(u_plane.height().get(), 1);
+    assert_eq!(u_plane.width(), 1);
+    assert_eq!(u_plane.height(), 1);
 }
 
 #[test]
@@ -338,7 +338,7 @@ fn builder_setters() {
         .luma_padding_bottom(8)
         .build::<u8>()
         .unwrap();
-    assert!(frame.y_plane.width().get() == 1920);
+    assert!(frame.y_plane.width() == 1920);
 }
 
 #[test]
@@ -352,6 +352,6 @@ fn asymmetric_padding() {
         .unwrap();
 
     // Visible dimensions should remain unchanged
-    assert_eq!(frame.y_plane.width().get(), 1920);
-    assert_eq!(frame.y_plane.height().get(), 1080);
+    assert_eq!(frame.y_plane.width(), 1920);
+    assert_eq!(frame.y_plane.height(), 1080);
 }

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -47,7 +47,6 @@ mod tests;
 
 #[cfg(feature = "padding_api")]
 use std::mem::MaybeUninit;
-use std::num::NonZeroUsize;
 
 mod aligned;
 use aligned::AlignedData;
@@ -99,28 +98,22 @@ pub struct Plane<T> {
 }
 
 impl<T> Plane<T> {
-    /// Returns the visible width of the plane in pixels
-    #[inline]
-    #[must_use]
-    pub fn width(&self) -> NonZeroUsize {
-        self.geometry.width
-    }
-
-    /// Returns the visible height of the plane in pixels
-    #[inline]
-    #[must_use]
-    pub fn height(&self) -> NonZeroUsize {
-        self.geometry.height
-    }
-
-    /// Returns the index for the first visible pixel in `data`.
+    /// Returns the visible width of the plane in pixels.
     ///
-    /// This is a low-level API intended only for functions that require access to the padding.
+    /// Guaranteed to be non-zero.
     #[inline]
     #[must_use]
-    #[cfg_attr(not(feature = "padding_api"), doc(hidden))]
-    pub fn data_origin(&self) -> usize {
-        self.geometry.stride.get() * self.geometry.pad_top + self.geometry.pad_left
+    pub fn width(&self) -> usize {
+        self.geometry.width()
+    }
+
+    /// Returns the visible height of the plane in pixels.
+    ///
+    /// Guaranteed to be non-zero.
+    #[inline]
+    #[must_use]
+    pub fn height(&self) -> usize {
+        self.geometry.height()
     }
 }
 
@@ -168,12 +161,7 @@ impl<T> Plane<T> {
     #[inline]
     #[must_use]
     pub fn new_uninit(geometry: PlaneGeometry) -> Plane<MaybeUninit<T>> {
-        let geometry = geometry
-            .normalized()
-            .expect("plane geometry dimensions must not overflow");
-        let pixels = geometry
-            .allocation_len()
-            .expect("plane allocation size must not overflow usize");
+        let pixels = geometry.alloc_size();
 
         Plane {
             data: AlignedData::new_uninit(pixels),
@@ -232,12 +220,7 @@ impl<T> Plane<MaybeUninit<T>> {
 impl<T: Pixel> Plane<T> {
     /// Creates a new plane with the given geometry, initialized with zero-valued pixels.
     pub(crate) fn new(geometry: PlaneGeometry) -> Self {
-        let geometry = geometry
-            .normalized()
-            .expect("plane geometry dimensions must not overflow");
-        let pixels = geometry
-            .allocation_len()
-            .expect("plane allocation size must not overflow usize");
+        let pixels = geometry.alloc_size();
 
         Self {
             data: AlignedData::new(pixels),
@@ -267,12 +250,12 @@ impl<T: Pixel> Plane<T> {
     #[must_use]
     pub fn rows(&self) -> impl DoubleEndedIterator<Item = &[T]> + ExactSizeIterator {
         self.data
-            .chunks_exact(self.geometry.stride.get())
-            .skip(self.geometry.pad_top)
-            .take(self.geometry.height.get())
+            .chunks_exact(self.geometry.stride())
+            .skip(self.geometry.pad_top())
+            .take(self.geometry.height())
             .map(|row| {
-                let start_idx = self.geometry.pad_left;
-                let end_idx = start_idx + self.geometry.width.get();
+                let start_idx = self.geometry.pad_left();
+                let end_idx = start_idx + self.geometry.width();
                 // SAFETY: The plane creation interface ensures the data is large enough
                 unsafe { row.get_unchecked(start_idx..end_idx) }
             })
@@ -283,12 +266,12 @@ impl<T: Pixel> Plane<T> {
     #[inline]
     pub fn rows_mut(&mut self) -> impl DoubleEndedIterator<Item = &mut [T]> + ExactSizeIterator {
         self.data
-            .chunks_exact_mut(self.geometry.stride.get())
-            .skip(self.geometry.pad_top)
-            .take(self.geometry.height.get())
+            .chunks_exact_mut(self.geometry.stride())
+            .skip(self.geometry.pad_top())
+            .take(self.geometry.height())
             .map(|row| {
-                let start_idx = self.geometry.pad_left;
-                let end_idx = start_idx + self.geometry.width.get();
+                let start_idx = self.geometry.pad_left();
+                let end_idx = start_idx + self.geometry.width();
                 // SAFETY: The plane creation interface ensures the data is large enough
                 unsafe { row.get_unchecked_mut(start_idx..end_idx) }
             })
@@ -302,7 +285,7 @@ impl<T: Pixel> Plane<T> {
     #[inline]
     #[must_use]
     pub fn pixel(&self, x: usize, y: usize) -> Option<T> {
-        let index = self.data_origin() + self.geometry.stride.get() * y + x;
+        let index = self.geometry.data_origin() + self.geometry.stride() * y + x;
         self.data.get(index).copied()
     }
 
@@ -313,7 +296,7 @@ impl<T: Pixel> Plane<T> {
     /// and should not be used to iterate over rows and pixels.
     #[inline]
     pub fn pixel_mut(&mut self, x: usize, y: usize) -> Option<&mut T> {
-        let index = self.data_origin() + self.geometry.stride.get() * y + x;
+        let index = self.geometry.data_origin() + self.geometry.stride() * y + x;
         self.data.get_mut(index)
     }
 
@@ -322,7 +305,7 @@ impl<T: Pixel> Plane<T> {
     #[inline]
     #[must_use]
     pub fn pixels(&self) -> impl DoubleEndedIterator<Item = T> + ExactSizeIterator {
-        let total = self.width().get() * self.height().get();
+        let total = self.width() * self.height();
         ExactSizeWrapper {
             iter: self.rows().flatten().copied(),
             len: total,
@@ -333,7 +316,7 @@ impl<T: Pixel> Plane<T> {
     /// in row-major order.
     #[inline]
     pub fn pixels_mut(&mut self) -> impl DoubleEndedIterator<Item = &mut T> + ExactSizeIterator {
-        let total = self.width().get() * self.height().get();
+        let total = self.width() * self.height();
         ExactSizeWrapper {
             iter: self.rows_mut().flatten(),
             len: total,
@@ -352,7 +335,7 @@ impl<T: Pixel> Plane<T> {
             "unsupported pixel byte width: {byte_width}"
         );
 
-        let total = self.width().get() * self.height().get() * byte_width;
+        let total = self.width() * self.height() * byte_width;
         ExactSizeWrapper {
             iter: self.pixels().flat_map(move |pix| {
                 let bytes: [u8; 2] = if byte_width == 1 {
@@ -379,8 +362,8 @@ impl<T: Pixel> Plane<T> {
     ///   this plane's `width * height`
     #[inline]
     pub fn copy_from_slice(&mut self, src: &[T]) -> Result<(), CopyError> {
-        let width = self.width().get();
-        let pixel_count = width * self.height().get();
+        let width = self.width();
+        let pixel_count = width * self.height();
         if pixel_count != src.len() {
             return Err(CopyError::DataLength {
                 expected: pixel_count,
@@ -407,7 +390,7 @@ impl<T: Pixel> Plane<T> {
     ///   this plane's `width * height * bytes_per_pixel`
     #[inline]
     pub fn copy_from_u8_slice(&mut self, src: &[u8]) -> Result<(), CopyError> {
-        self.copy_from_u8_slice_with_stride(src, self.width().get() * size_of::<T>())
+        self.copy_from_u8_slice_with_stride(src, self.width() * size_of::<T>())
     }
 
     /// Copies the data from `src` into this plane's visible pixels.
@@ -430,14 +413,14 @@ impl<T: Pixel> Plane<T> {
             "unsupported pixel byte width: {byte_width}"
         );
 
-        if stride < self.width().get() {
+        if stride < self.width() {
             return Err(CopyError::InvalidStride {
                 stride,
-                width: self.width().get(),
+                width: self.width(),
             });
         }
 
-        let byte_count = stride * self.height().get();
+        let byte_count = stride * self.height();
         if byte_count != src.len() {
             return Err(CopyError::DataLength {
                 expected: byte_count,
@@ -445,7 +428,7 @@ impl<T: Pixel> Plane<T> {
             });
         }
 
-        let width = self.width().get();
+        let width = self.width();
         if byte_width == 1 {
             // Fast path for u8 pixels
             for (row_idx, dest_row) in self.rows_mut().enumerate() {

--- a/src/plane/geometry.rs
+++ b/src/plane/geometry.rs
@@ -11,31 +11,16 @@ use crate::chroma::ChromaSubsampling;
 /// The `stride` represents the number of pixels per row in the data buffer,
 /// which is equal to `width + pad_left + pad_right`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[expect(clippy::manual_non_exhaustive)]
 pub struct PlaneGeometry {
-    /// Width of the visible area in pixels.
-    pub width: NonZeroUsize,
-    /// Height of the visible area in pixels.
-    pub height: NonZeroUsize,
-    /// Data stride (pixels per row in the buffer, including padding).
-    pub stride: NonZeroUsize,
-    /// Number of padding pixels on the left side.
-    pub pad_left: usize,
-    /// Number of padding pixels on the right side.
-    pub pad_right: usize,
-    /// Number of padding pixels on the top.
-    pub pad_top: usize,
-    /// Number of padding pixels on the bottom.
-    pub pad_bottom: usize,
-    /// The horizontal subsampling ratio of this plane compared to the luma plane
-    /// Will be 1 if no subsampling
-    pub subsampling_x: NonZeroU8,
-    /// The horizontal subsampling ratio of this plane compared to the luma plane
-    /// Will be 1 if no subsampling
-    pub subsampling_y: NonZeroU8,
-
-    // No manual instantiation outside of this module
-    _marker: (),
+    width: NonZeroUsize,
+    height: NonZeroUsize,
+    stride: NonZeroUsize,
+    pad_left: usize,
+    pad_right: usize,
+    pad_top: usize,
+    pad_bottom: usize,
+    subsampling_x: NonZeroU8,
+    subsampling_y: NonZeroU8,
 }
 
 impl PlaneGeometry {
@@ -74,7 +59,6 @@ impl PlaneGeometry {
             pad_bottom,
             subsampling_x,
             subsampling_y,
-            _marker: (),
         })
     }
 
@@ -92,27 +76,77 @@ impl PlaneGeometry {
         Self::new(width, height, 0, 0, 0, 0, subsampling_x, subsampling_y)
     }
 
+    /// Width of the visible area in pixels.
+    ///
+    /// Guaranteed to be non-zero.
     #[inline]
-    pub(crate) fn normalized(self) -> Option<Self> {
-        Self::new(
-            self.width.get(),
-            self.height.get(),
-            self.pad_left,
-            self.pad_right,
-            self.pad_top,
-            self.pad_bottom,
-            self.subsampling_x.get(),
-            self.subsampling_y.get(),
-        )
+    #[must_use]
+    pub fn width(&self) -> usize {
+        self.width.get()
     }
 
+    /// Height of the visible area in pixels.
+    ///
+    /// Guaranteed to be non-zero.
     #[inline]
-    pub(crate) fn allocation_len(self) -> Option<usize> {
-        self.height
-            .get()
-            .checked_add(self.pad_top)?
-            .checked_add(self.pad_bottom)?
-            .checked_mul(self.stride.get())
+    #[must_use]
+    pub fn height(&self) -> usize {
+        self.height.get()
+    }
+
+    /// Data stride (pixels per row in the buffer, including padding).
+    ///
+    /// Guaranteed to be non-zero.
+    #[inline]
+    #[must_use]
+    pub fn stride(&self) -> usize {
+        self.stride.get()
+    }
+
+    /// Number of padding pixels on the left side.
+    #[inline]
+    #[must_use]
+    pub fn pad_left(&self) -> usize {
+        self.pad_left
+    }
+
+    /// Number of padding pixels on the right side.
+    #[inline]
+    #[must_use]
+    pub fn pad_right(&self) -> usize {
+        self.pad_right
+    }
+
+    /// Number of padding pixels on the top.
+    #[inline]
+    #[must_use]
+    pub fn pad_top(&self) -> usize {
+        self.pad_top
+    }
+
+    /// Number of padding pixels on the bottom.
+    #[inline]
+    #[must_use]
+    pub fn pad_bottom(&self) -> usize {
+        self.pad_bottom
+    }
+
+    /// The horizontal subsampling ratio of this plane compared to the luma plane.
+    ///
+    /// Guaranteed to be non-zero, and 1 if not subsampled.
+    #[inline]
+    #[must_use]
+    pub fn subsampling_x(&self) -> u8 {
+        self.subsampling_x.get()
+    }
+
+    /// The horizontal subsampling ratio of this plane compared to the luma plane.
+    ///
+    /// Guaranteed to be non-zero, and 1 if not subsampled.
+    #[inline]
+    #[must_use]
+    pub fn subsampling_y(&self) -> u8 {
+        self.subsampling_y.get()
     }
 
     /// Returns a new [`PlaneGeometry`] based on `self` and according to `subsampling`.
@@ -170,14 +204,25 @@ impl PlaneGeometry {
         .ok_or(SubsamplingError)
     }
 
-    /// Returns the total height of the plane, including padding
+    /// Returns the index for the first visible pixel.
     #[inline]
     #[must_use]
-    #[cfg_attr(not(feature = "padding_api"), doc(hidden))]
-    pub fn alloc_height(&self) -> NonZeroUsize {
-        self.height
-            .saturating_add(self.pad_top)
-            .saturating_add(self.pad_bottom)
+    pub fn data_origin(&self) -> usize {
+        self.stride() * self.pad_top + self.pad_left
+    }
+
+    /// Returns the total height of the plane, including padding.
+    #[inline]
+    #[must_use]
+    pub fn alloc_height(&self) -> usize {
+        self.height() + self.pad_top + self.pad_bottom
+    }
+
+    /// Returns the total allocation size of the plane, including padding.
+    #[inline]
+    #[must_use]
+    pub fn alloc_size(&self) -> usize {
+        self.alloc_height() * self.stride()
     }
 }
 

--- a/src/plane/geometry.rs
+++ b/src/plane/geometry.rs
@@ -247,15 +247,15 @@ mod tests {
         assert!(PlaneGeometry::unpadded(1920, 1080, 1, 0).is_none());
 
         let g = PlaneGeometry::unpadded(1920, 1080, 1, 1).expect("unpadded geometry works");
-        assert_eq!(g.width.get(), 1920);
-        assert_eq!(g.height.get(), 1080);
+        assert_eq!(g.width(), 1920);
+        assert_eq!(g.height(), 1080);
         assert_eq!(g.stride, g.width);
-        assert_eq!(g.pad_left, 0);
-        assert_eq!(g.pad_right, 0);
-        assert_eq!(g.pad_top, 0);
-        assert_eq!(g.pad_bottom, 0);
-        assert_eq!(g.subsampling_x.get(), 1);
-        assert_eq!(g.subsampling_y.get(), 1);
+        assert_eq!(g.pad_left(), 0);
+        assert_eq!(g.pad_right(), 0);
+        assert_eq!(g.pad_top(), 0);
+        assert_eq!(g.pad_bottom(), 0);
+        assert_eq!(g.subsampling_x(), 1);
+        assert_eq!(g.subsampling_y(), 1);
     }
 
     #[test]
@@ -266,15 +266,15 @@ mod tests {
         assert!(PlaneGeometry::new(1920, 1080, 40, 30, 20, 10, 1, 0).is_none());
 
         let g = PlaneGeometry::new(1920, 1080, 40, 30, 20, 10, 1, 1).expect("new geometry works");
-        assert_eq!(g.width.get(), 1920);
-        assert_eq!(g.height.get(), 1080);
-        assert_eq!(g.stride.get(), 1920 + 40 + 30);
-        assert_eq!(g.pad_left, 40);
-        assert_eq!(g.pad_right, 30);
-        assert_eq!(g.pad_top, 20);
-        assert_eq!(g.pad_bottom, 10);
-        assert_eq!(g.subsampling_x.get(), 1);
-        assert_eq!(g.subsampling_y.get(), 1);
+        assert_eq!(g.width(), 1920);
+        assert_eq!(g.height(), 1080);
+        assert_eq!(g.stride(), 1920 + 40 + 30);
+        assert_eq!(g.pad_left(), 40);
+        assert_eq!(g.pad_right(), 30);
+        assert_eq!(g.pad_top(), 20);
+        assert_eq!(g.pad_bottom(), 10);
+        assert_eq!(g.subsampling_x(), 1);
+        assert_eq!(g.subsampling_y(), 1);
     }
 
     #[test]
@@ -299,29 +299,29 @@ mod tests {
             .for_subsampling(ChromaSubsampling::Yuv422)
             .expect("can subsample to Yuv422")
             .expect("subsampled plane exists for Yuv422");
-        assert_eq!(sub.width.get(), 960);
-        assert_eq!(sub.height.get(), 1080);
-        assert_eq!(sub.stride.get(), 960 + 20 + 15);
-        assert_eq!(sub.pad_left, 20);
-        assert_eq!(sub.pad_right, 15);
-        assert_eq!(sub.pad_top, 20);
-        assert_eq!(sub.pad_bottom, 10);
-        assert_eq!(sub.subsampling_x.get(), 2);
-        assert_eq!(sub.subsampling_y.get(), 1);
+        assert_eq!(sub.width(), 960);
+        assert_eq!(sub.height(), 1080);
+        assert_eq!(sub.stride(), 960 + 20 + 15);
+        assert_eq!(sub.pad_left(), 20);
+        assert_eq!(sub.pad_right(), 15);
+        assert_eq!(sub.pad_top(), 20);
+        assert_eq!(sub.pad_bottom(), 10);
+        assert_eq!(sub.subsampling_x(), 2);
+        assert_eq!(sub.subsampling_y(), 1);
 
         let sub = g
             .for_subsampling(ChromaSubsampling::Yuv420)
             .expect("can subsample to Yuv420")
             .expect("subsampled plane exists for Yuv420");
-        assert_eq!(sub.width.get(), 960);
-        assert_eq!(sub.height.get(), 540);
-        assert_eq!(sub.stride.get(), 960 + 20 + 15);
+        assert_eq!(sub.width(), 960);
+        assert_eq!(sub.height(), 540);
+        assert_eq!(sub.stride(), 960 + 20 + 15);
         assert_eq!(sub.pad_left, 20);
         assert_eq!(sub.pad_right, 15);
         assert_eq!(sub.pad_top, 10);
         assert_eq!(sub.pad_bottom, 5);
-        assert_eq!(sub.subsampling_x.get(), 2);
-        assert_eq!(sub.subsampling_y.get(), 2);
+        assert_eq!(sub.subsampling_x(), 2);
+        assert_eq!(sub.subsampling_y(), 2);
     }
 
     #[test]

--- a/src/plane/tests.rs
+++ b/src/plane/tests.rs
@@ -36,8 +36,8 @@ fn plane_new_u8() {
     let geometry = simple_geometry(4, 4);
     let plane: Plane<u8> = Plane::new(geometry);
 
-    assert_eq!(plane.width().get(), 4);
-    assert_eq!(plane.height().get(), 4);
+    assert_eq!(plane.width(), 4);
+    assert_eq!(plane.height(), 4);
 
     // All pixels should be initialized to zero
     for pixel in plane.pixels() {
@@ -50,8 +50,8 @@ fn plane_new_u16() {
     let geometry = simple_geometry(8, 8);
     let plane: Plane<u16> = Plane::new(geometry);
 
-    assert_eq!(plane.width().get(), 8);
-    assert_eq!(plane.height().get(), 8);
+    assert_eq!(plane.width(), 8);
+    assert_eq!(plane.height(), 8);
 
     // All pixels should be initialized to zero
     for pixel in plane.pixels() {
@@ -59,27 +59,13 @@ fn plane_new_u16() {
     }
 }
 
-#[cfg(miri)]
-#[test]
-fn mutable_geometry_fields_can_break_row_slice_invariant() {
-    let mut geometry = simple_geometry(1, 1);
-    geometry.pad_left = 1;
-
-    // Regression test: `PlaneGeometry` fields are public, so constructors must
-    // restore the dependent `stride = width + pad_left + pad_right` invariant
-    // before row iteration relies on it.
-    let plane: Plane<u8> = Plane::new(geometry);
-    assert_eq!(plane.geometry.stride.get(), 2);
-    assert_eq!(plane.rows().next(), Some(&[0][..]));
-}
-
 #[test]
 fn plane_dimensions() {
     let geometry = simple_geometry(16, 9);
     let plane: Plane<u8> = Plane::new(geometry);
 
-    assert_eq!(plane.width().get(), 16);
-    assert_eq!(plane.height().get(), 9);
+    assert_eq!(plane.width(), 16);
+    assert_eq!(plane.height(), 9);
 }
 
 #[test]
@@ -300,8 +286,8 @@ fn plane_with_padding() {
     let mut plane: Plane<u8> = Plane::new(geometry);
 
     // Width and height should reflect visible area
-    assert_eq!(plane.width().get(), 4);
-    assert_eq!(plane.height().get(), 3);
+    assert_eq!(plane.width(), 4);
+    assert_eq!(plane.height(), 3);
 
     // Fill visible pixels
     for (i, pixel) in plane.pixels_mut().enumerate() {
@@ -368,8 +354,7 @@ fn plane_debug() {
                 pad_top: 0, \
                 pad_bottom: 0, \
                 subsampling_x: 1, \
-                subsampling_y: 1, \
-                _marker: () \
+                subsampling_y: 1 \
             } \
         }"
     );
@@ -380,7 +365,7 @@ fn data_origin_no_padding() {
     let geometry = simple_geometry(4, 4);
     let plane: Plane<u8> = Plane::new(geometry);
 
-    assert_eq!(plane.data_origin(), 0);
+    assert_eq!(plane.geometry.data_origin(), 0);
 }
 
 #[test]
@@ -389,7 +374,7 @@ fn data_origin_with_padding() {
     let plane: Plane<u8> = Plane::new(geometry);
 
     // Origin should be: stride * pad_top + pad_left = 8 * 1 + 2 = 10
-    assert_eq!(plane.data_origin(), 10);
+    assert_eq!(plane.geometry.data_origin(), 10);
 }
 
 #[cfg(feature = "padding_api")]
@@ -410,7 +395,7 @@ fn padding_api_geometry_alloc_height() {
 
     assert_eq!(
         plane.data().len(),
-        geometry.alloc_height().get() * geometry.stride.get()
+        geometry.alloc_height() * geometry.stride()
     );
 }
 
@@ -557,8 +542,8 @@ fn large_plane() {
     let geometry = simple_geometry(1920, 1080);
     let plane: Plane<u8> = Plane::new(geometry);
 
-    assert_eq!(plane.width().get(), 1920);
-    assert_eq!(plane.height().get(), 1080);
+    assert_eq!(plane.width(), 1920);
+    assert_eq!(plane.height(), 1080);
     assert_eq!(plane.pixels().count(), 1920 * 1080);
 }
 


### PR DESCRIPTION
These should not have been public in the first place. This makes invalid state between geometry and data impossible (fixing any problems related to #61) and results in a nicer API overall.

Basically: Plane and AlignedData have safety invariants that depend on the state of PlaneGeometry when `Plane::new` is called. By both validating the geometry in its constructor and making it fully immutable, we ensure that the invariants are always fulfilled.

This also means we can remove the re-validation of geometry (part of #74) from `Plane::new`.

Changes:
- add getters
- make getters return zeroable scalars over NonZero<T>. With `#[inline]` this should elide unnecessary `width != 0` checks downstream while making the API simpler (`plane.width().get()` -> `plane.width()`)
- move data_origin from Plane to geometry, not something downstream needs without padding awareness (-> `-F padding_api`)
